### PR TITLE
Show last attempt history per item

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,6 +143,34 @@
         user-select: none;
     }
 
+    .attempt-history {
+      display: flex;
+      gap: 6px;
+      margin-top: 8px;
+      align-items: center;
+    }
+
+    .attempt-dot {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      display: inline-block;
+      background-color: #bdbdbd;
+    }
+
+    .attempt-dot-success {
+      background-color: #4caf50;
+    }
+
+    .attempt-dot-failure {
+      background-color: #e53935;
+    }
+
+    .attempt-dot-empty {
+      background-color: #e0e0e0;
+      opacity: 0.6;
+    }
+
     </style>
 </head>
 <body dir="rtl">

--- a/storage.js
+++ b/storage.js
@@ -68,6 +68,22 @@ function getWeightsKey(key){
     return getKey(`${getActivityMode()}_${key}_Weights`)
 }
 
+function recordAttemptResult(key, index, isSuccess, limit=3){
+    if (index === undefined || index === null){
+        return;
+    }
+    const storageKey = getKey(`${key}_attemptHistory`);
+    const history = getLocalStorage(`${key}_attemptHistory`, {});
+    const itemHistory = history[index] || [];
+    itemHistory.push(isSuccess);
+    history[index] = itemHistory.slice(-limit);
+    localStorage.setItem(storageKey, JSON.stringify(history));
+}
+
+function getAttemptHistory(key){
+    return getLocalStorage(`${key}_attemptHistory`, {});
+}
+
 function setVoice(lang, uri){
     console.log(`Set ${lang} ${uri}`)
     localStorage.setItem(`${lang}_voice`, uri);

--- a/storage.js
+++ b/storage.js
@@ -68,7 +68,7 @@ function getWeightsKey(key){
     return getKey(`${getActivityMode()}_${key}_Weights`)
 }
 
-function recordAttemptResult(key, index, isSuccess, limit=3){
+function recordAttemptResult(key, index, isSuccess, limit=5){
     if (index === undefined || index === null){
         return;
     }

--- a/tester.js
+++ b/tester.js
@@ -1490,8 +1490,8 @@ var AppComponent = Vue.component('app',{
         },
         getRecentAttempts: function(itemIndex){
             const attempts = this.attemptHistory[itemIndex] || [];
-            const recent = attempts.slice(-3);
-            while (recent.length < 3){
+            const recent = attempts.slice(-5);
+            while (recent.length < 5){
                 recent.unshift(null);
             }
             return recent;


### PR DESCRIPTION
## Summary
- track per-item attempt history when updating item weights
- expose attempt history on the app item listing with colored dot indicators
- add styles for the new attempt history display

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bfb592e40832e8a1e39549daa0d66)