### PR TITLE
Add plain-text `english` fields to 0_28 vocab and use them for Hebrew→English games

### DIFF
--- a/apps.js
+++ b/apps.js
@@ -66,6 +66,40 @@ apps =  {
         {icon: 'format_shapes', name:'שלג', type: 'app', appType: 'mcq', listName: 'SNOW', questionIndex: 'english_name', resultIndex:'name', setItems: 3},
        ]
       },
+        {
+          name: 'מילים לחזרה למבחן',
+          type: 'menu',
+          items: [
+            {
+              name: 'אנגלית לעברית',
+              type: 'menu',
+              items: [
+                {icon: 'format_shapes', name:'בגדים', type: 'app', appType: 'mcq', listName: 'ENGLISH_0_28_CLOTHING', questionIndex: 'english_name', resultIndex: 'hebrew'},
+                {icon: 'format_shapes', name:'אוכל ושתייה', type: 'app', appType: 'mcq', listName: 'ENGLISH_0_28_FOOD_AND_DRINK', questionIndex: 'english_name', resultIndex: 'hebrew'},
+                {icon: 'format_shapes', name:'פעולות וביטויים', type: 'app', appType: 'mcq', listName: 'ENGLISH_0_28_ACTIONS_AND_PHRASES', questionIndex: 'english_name', resultIndex: 'hebrew'},
+                {icon: 'format_shapes', name:'מספרים', type: 'app', appType: 'mcq', listName: 'ENGLISH_0_28_NUMBERS', questionIndex: 'english_name', resultIndex: 'hebrew'},
+                {icon: 'format_shapes', name:'תיאורים', type: 'app', appType: 'mcq', listName: 'ENGLISH_0_28_DESCRIPTIONS', questionIndex: 'english_name', resultIndex: 'hebrew'},
+                {icon: 'format_shapes', name:'מקומות וחדרים', type: 'app', appType: 'mcq', listName: 'ENGLISH_0_28_PLACES_AND_ROOMS', questionIndex: 'english_name', resultIndex: 'hebrew'},
+                {icon: 'format_shapes', name:'שונות', type: 'app', appType: 'mcq', listName: 'ENGLISH_0_28_MISC', questionIndex: 'english_name', resultIndex: 'hebrew'},
+                {icon: 'format_shapes', name:'הכל', type: 'app', appType: 'mcq', listName: 'ENGLISH_0_28_ALL', questionIndex: 'english_name', resultIndex: 'hebrew'},
+              ]
+            },
+            {
+              name: 'עברית לאנגלית',
+              type: 'menu',
+              items: [
+                {icon: 'format_shapes', name:'בגדים', type: 'app', appType: 'mcq', listName: 'ENGLISH_0_28_CLOTHING', questionIndex: 'hebrew', resultIndex: 'english'},
+                {icon: 'format_shapes', name:'אוכל ושתייה', type: 'app', appType: 'mcq', listName: 'ENGLISH_0_28_FOOD_AND_DRINK', questionIndex: 'hebrew', resultIndex: 'english'},
+                {icon: 'format_shapes', name:'פעולות וביטויים', type: 'app', appType: 'mcq', listName: 'ENGLISH_0_28_ACTIONS_AND_PHRASES', questionIndex: 'hebrew', resultIndex: 'english'},
+                {icon: 'format_shapes', name:'מספרים', type: 'app', appType: 'mcq', listName: 'ENGLISH_0_28_NUMBERS', questionIndex: 'hebrew', resultIndex: 'english'},
+                {icon: 'format_shapes', name:'תיאורים', type: 'app', appType: 'mcq', listName: 'ENGLISH_0_28_DESCRIPTIONS', questionIndex: 'hebrew', resultIndex: 'english'},
+                {icon: 'format_shapes', name:'מקומות וחדרים', type: 'app', appType: 'mcq', listName: 'ENGLISH_0_28_PLACES_AND_ROOMS', questionIndex: 'hebrew', resultIndex: 'english'},
+                {icon: 'format_shapes', name:'שונות', type: 'app', appType: 'mcq', listName: 'ENGLISH_0_28_MISC', questionIndex: 'hebrew', resultIndex: 'english'},
+                {icon: 'format_shapes', name:'הכל', type: 'app', appType: 'mcq', listName: 'ENGLISH_0_28_ALL', questionIndex: 'hebrew', resultIndex: 'english'},
+              ]
+            },
+          ]
+        },
       ]
     },
     {

--- a/data.js
+++ b/data.js
@@ -6578,6 +6578,89 @@ ENGLISH_VOCAB_MISC: [
   {"hebrew": {"type": "text", "value": "ארוחת צהריים"}, "english_name": {"type": "text_to_speech", "value": "Lunch"}}
 ],
 
+ENGLISH_0_28_CLOTHING: [
+  {"hebrew": {"type": "text", "value": "מגפיים"}, "english": {"type": "text", "value": "Boots"}, "english_name": {"type": "text_to_speech", "value": "Boots"}},
+  {"hebrew": {"type": "text", "value": "בגדים"}, "english": {"type": "text", "value": "Clothes"}, "english_name": {"type": "text_to_speech", "value": "Clothes"}},
+  {"hebrew": {"type": "text", "value": "מעיל"}, "english": {"type": "text", "value": "Coat"}, "english_name": {"type": "text_to_speech", "value": "Coat"}},
+  {"hebrew": {"type": "text", "value": "שמלה"}, "english": {"type": "text", "value": "Dress"}, "english_name": {"type": "text_to_speech", "value": "Dress"}},
+  {"hebrew": {"type": "text", "value": "חולצה"}, "english": {"type": "text", "value": "Shirt"}, "english_name": {"type": "text_to_speech", "value": "Shirt"}},
+  {"hebrew": {"type": "text", "value": "מכנסיים"}, "english": {"type": "text", "value": "Pants"}, "english_name": {"type": "text_to_speech", "value": "Pants"}},
+  {"hebrew": {"type": "text", "value": "נעליים"}, "english": {"type": "text", "value": "Shoes"}, "english_name": {"type": "text_to_speech", "value": "Shoes"}},
+  {"hebrew": {"type": "text", "value": "חצאית"}, "english": {"type": "text", "value": "Skirt"}, "english_name": {"type": "text_to_speech", "value": "Skirt"}},
+  {"hebrew": {"type": "text", "value": "גרביים"}, "english": {"type": "text", "value": "Socks"}, "english_name": {"type": "text_to_speech", "value": "Socks"}},
+  {"hebrew": {"type": "text", "value": "סוודר"}, "english": {"type": "text", "value": "Sweater"}, "english_name": {"type": "text_to_speech", "value": "Sweater"}}
+],
+
+ENGLISH_0_28_FOOD_AND_DRINK: [
+  {"hebrew": {"type": "text", "value": "עוגה"}, "english": {"type": "text", "value": "Cake"}, "english_name": {"type": "text_to_speech", "value": "Cake"}},
+  {"hebrew": {"type": "text", "value": "מילקשייק"}, "english": {"type": "text", "value": "Milkshake"}, "english_name": {"type": "text_to_speech", "value": "Milkshake"}}
+],
+
+ENGLISH_0_28_ACTIONS_AND_PHRASES: [
+  {"hebrew": {"type": "text", "value": "לקחת"}, "english": {"type": "text", "value": "Take"}, "english_name": {"type": "text_to_speech", "value": "Take"}},
+  {"hebrew": {"type": "text", "value": "לכתוב"}, "english": {"type": "text", "value": "Write"}, "english_name": {"type": "text_to_speech", "value": "Write"}},
+  {"hebrew": {"type": "text", "value": "לאהוב"}, "english": {"type": "text", "value": "Like"}, "english_name": {"type": "text_to_speech", "value": "Like"}},
+  {"hebrew": {"type": "text", "value": "ללבוש"}, "english": {"type": "text", "value": "Put on"}, "english_name": {"type": "text_to_speech", "value": "Put on"}},
+  {"hebrew": {"type": "text", "value": "להוריד"}, "english": {"type": "text", "value": "Take off"}, "english_name": {"type": "text_to_speech", "value": "Take off"}},
+  {"hebrew": {"type": "text", "value": "לקנות"}, "english": {"type": "text", "value": "Buy"}, "english_name": {"type": "text_to_speech", "value": "Buy"}},
+  {"hebrew": {"type": "text", "value": "לישון"}, "english": {"type": "text", "value": "Sleep"}, "english_name": {"type": "text_to_speech", "value": "Sleep"}},
+  {"hebrew": {"type": "text", "value": "נקי"}, "english": {"type": "text", "value": "Clean"}, "english_name": {"type": "text_to_speech", "value": "Clean"}},
+  {"hebrew": {"type": "text", "value": "כמה זה עולה"}, "english": {"type": "text", "value": "How much is it"}, "english_name": {"type": "text_to_speech", "value": "How much is it"}}
+],
+
+ENGLISH_0_28_NUMBERS: [
+  {"hebrew": {"type": "text", "value": "חמש"}, "english": {"type": "text", "value": "Five"}, "english_name": {"type": "text_to_speech", "value": "Five"}},
+  {"hebrew": {"type": "text", "value": "תשע"}, "english": {"type": "text", "value": "Nine"}, "english_name": {"type": "text_to_speech", "value": "Nine"}},
+  {"hebrew": {"type": "text", "value": "עשרים"}, "english": {"type": "text", "value": "Twenty"}, "english_name": {"type": "text_to_speech", "value": "Twenty"}},
+  {"hebrew": {"type": "text", "value": "עשר"}, "english": {"type": "text", "value": "Ten"}, "english_name": {"type": "text_to_speech", "value": "Ten"}},
+  {"hebrew": {"type": "text", "value": "חמישים"}, "english": {"type": "text", "value": "Fifty"}, "english_name": {"type": "text_to_speech", "value": "Fifty"}},
+  {"hebrew": {"type": "text", "value": "שלושים"}, "english": {"type": "text", "value": "Thirty"}, "english_name": {"type": "text_to_speech", "value": "Thirty"}},
+  {"hebrew": {"type": "text", "value": "מאה"}, "english": {"type": "text", "value": "One hundred"}, "english_name": {"type": "text_to_speech", "value": "One hundred"}},
+  {"hebrew": {"type": "text", "value": "שישים"}, "english": {"type": "text", "value": "Sixty"}, "english_name": {"type": "text_to_speech", "value": "Sixty"}},
+  {"hebrew": {"type": "text", "value": "שמונים"}, "english": {"type": "text", "value": "Eighty"}, "english_name": {"type": "text_to_speech", "value": "Eighty"}},
+  {"hebrew": {"type": "text", "value": "ארבעים"}, "english": {"type": "text", "value": "Forty"}, "english_name": {"type": "text_to_speech", "value": "Forty"}},
+  {"hebrew": {"type": "text", "value": "תשעים"}, "english": {"type": "text", "value": "Ninety"}, "english_name": {"type": "text_to_speech", "value": "Ninety"}},
+  {"hebrew": {"type": "text", "value": "שבעים"}, "english": {"type": "text", "value": "Seventy"}, "english_name": {"type": "text_to_speech", "value": "Seventy"}}
+],
+
+ENGLISH_0_28_DESCRIPTIONS: [
+  {"hebrew": {"type": "text", "value": "קר"}, "english": {"type": "text", "value": "Cold"}, "english_name": {"type": "text_to_speech", "value": "Cold"}},
+  {"hebrew": {"type": "text", "value": "ארוך"}, "english": {"type": "text", "value": "Long"}, "english_name": {"type": "text_to_speech", "value": "Long"}},
+  {"hebrew": {"type": "text", "value": "חם"}, "english": {"type": "text", "value": "Warm"}, "english_name": {"type": "text_to_speech", "value": "Warm"}},
+  {"hebrew": {"type": "text", "value": "לבן"}, "english": {"type": "text", "value": "White"}, "english_name": {"type": "text_to_speech", "value": "White"}},
+  {"hebrew": {"type": "text", "value": "חדש"}, "english": {"type": "text", "value": "New"}, "english_name": {"type": "text_to_speech", "value": "New"}},
+  {"hebrew": {"type": "text", "value": "ישן"}, "english": {"type": "text", "value": "Old"}, "english_name": {"type": "text_to_speech", "value": "Old"}},
+  {"hebrew": {"type": "text", "value": "סגור"}, "english": {"type": "text", "value": "Close"}, "english_name": {"type": "text_to_speech", "value": "Close"}},
+  {"hebrew": {"type": "text", "value": "מאוחר"}, "english": {"type": "text", "value": "Late"}, "english_name": {"type": "text_to_speech", "value": "Late"}},
+  {"hebrew": {"type": "text", "value": "יותר"}, "english": {"type": "text", "value": "More"}, "english_name": {"type": "text_to_speech", "value": "More"}},
+  {"hebrew": {"type": "text", "value": "מידה"}, "english": {"type": "text", "value": "Size"}, "english_name": {"type": "text_to_speech", "value": "Size"}}
+],
+
+ENGLISH_0_28_PLACES_AND_ROOMS: [
+  {"hebrew": {"type": "text", "value": "בית"}, "english": {"type": "text", "value": "Home"}, "english_name": {"type": "text_to_speech", "value": "Home"}},
+  {"hebrew": {"type": "text", "value": "חנות"}, "english": {"type": "text", "value": "Store"}, "english_name": {"type": "text_to_speech", "value": "Store"}},
+  {"hebrew": {"type": "text", "value": "סלון"}, "english": {"type": "text", "value": "Living room"}, "english_name": {"type": "text_to_speech", "value": "Living room"}},
+  {"hebrew": {"type": "text", "value": "חדר שינה"}, "english": {"type": "text", "value": "Bedroom"}, "english_name": {"type": "text_to_speech", "value": "Bedroom"}},
+  {"hebrew": {"type": "text", "value": "חדר אמבטיה"}, "english": {"type": "text", "value": "Bathroom"}, "english_name": {"type": "text_to_speech", "value": "Bathroom"}},
+  {"hebrew": {"type": "text", "value": "ארון"}, "english": {"type": "text", "value": "Closet"}, "english_name": {"type": "text_to_speech", "value": "Closet"}}
+],
+
+ENGLISH_0_28_MISC: [
+  {"hebrew": {"type": "text", "value": "שם"}, "english": {"type": "text", "value": "Name"}, "english_name": {"type": "text_to_speech", "value": "Name"}},
+  {"hebrew": {"type": "text", "value": "זמן"}, "english": {"type": "text", "value": "Time"}, "english_name": {"type": "text_to_speech", "value": "Time"}},
+  {"hebrew": {"type": "text", "value": "נחש"}, "english": {"type": "text", "value": "Snake"}, "english_name": {"type": "text_to_speech", "value": "Snake"}},
+  {"hebrew": {"type": "text", "value": "שולחן"}, "english": {"type": "text", "value": "Table"}, "english_name": {"type": "text_to_speech", "value": "Table"}},
+  {"hebrew": {"type": "text", "value": "מראה"}, "english": {"type": "text", "value": "Mirror"}, "english_name": {"type": "text_to_speech", "value": "Mirror"}},
+  {"hebrew": {"type": "text", "value": "אף"}, "english": {"type": "text", "value": "Nose"}, "english_name": {"type": "text_to_speech", "value": "Nose"}},
+  {"hebrew": {"type": "text", "value": "דלת"}, "english": {"type": "text", "value": "Door"}, "english_name": {"type": "text_to_speech", "value": "Door"}},
+  {"hebrew": {"type": "text", "value": "משחק"}, "english": {"type": "text", "value": "Game"}, "english_name": {"type": "text_to_speech", "value": "Game"}},
+  {"hebrew": {"type": "text", "value": "חיוך"}, "english": {"type": "text", "value": "Smile"}, "english_name": {"type": "text_to_speech", "value": "Smile"}},
+  {"hebrew": {"type": "text", "value": "חליל"}, "english": {"type": "text", "value": "Flute"}, "english_name": {"type": "text_to_speech", "value": "Flute"}},
+  {"hebrew": {"type": "text", "value": "חוק"}, "english": {"type": "text", "value": "Rule"}, "english_name": {"type": "text_to_speech", "value": "Rule"}}
+],
+
+ENGLISH_0_28_ALL: [],
+
 ENGLISH_VOCAB_ALL: [],
 
 ADDITION: createAsymmetricExercises(10, inverseAddition, "ADDITION"),
@@ -6600,6 +6683,17 @@ const ENGLISH_VOCABULARY_LISTS = [
     DATA.ENGLISH_VOCAB_MISC,
 ];
 DATA.ENGLISH_VOCAB_ALL = ENGLISH_VOCABULARY_LISTS.flat();
+
+const ENGLISH_0_28_LISTS = [
+    DATA.ENGLISH_0_28_CLOTHING,
+    DATA.ENGLISH_0_28_FOOD_AND_DRINK,
+    DATA.ENGLISH_0_28_ACTIONS_AND_PHRASES,
+    DATA.ENGLISH_0_28_NUMBERS,
+    DATA.ENGLISH_0_28_DESCRIPTIONS,
+    DATA.ENGLISH_0_28_PLACES_AND_ROOMS,
+    DATA.ENGLISH_0_28_MISC,
+];
+DATA.ENGLISH_0_28_ALL = ENGLISH_0_28_LISTS.flat();
 
 function filterABCByString(lettersStr, abcList) {
     const letterSet = new Set(lettersStr.split("")); // להאיץ את הבדיקה


### PR DESCRIPTION
### Motivation
- Provide a plain-text English value to use when the game direction is Hebrew→English instead of relying on TTS-only fields. 
- Ensure the new `0_28` vocabulary entries contain both a human-readable `english` field and the existing `english_name` TTS field. 
- Keep existing English→Hebrew behavior unchanged while enabling correct result matching for Hebrew→English exercises.

### Description
- Added `english` (type `text`) to every entry in the `ENGLISH_0_28_*` lists in `data.js` so each item now has `hebrew`, `english`, and `english_name` fields. 
- Created `ENGLISH_0_28_LISTS` and populated `DATA.ENGLISH_0_28_ALL` as the flattened aggregate of those lists in `data.js`. 
- Updated the exam-review menus in `apps.js` so the Hebrew→English menu items use `questionIndex: 'hebrew'` and `resultIndex: 'english'`, while English→Hebrew items continue to use `english_name`→`hebrew`. 
- Performed an automated transformation to inject the `english` fields into `data.js` and updated menu wiring in `apps.js` accordingly.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e473c1454832ea939a9cb50a39733)