### PR TITLE
Add 'to be' grammar practice sets and menu

### DIFF
--- a/apps.js
+++ b/apps.js
@@ -34,6 +34,18 @@ apps =  {
         {icon: 'record_voice_over', name: 'אמור את שם האות', type: 'app', appType: 's2t', listName: 'ABC', questionIndex: 'englishUpperCase', resultIndex: 'englishUpperCase', setItems: 5, title: 'אמור בקול את שם האות'},
 
         {
+          name: 'דקדוק - to be',
+          type: 'menu',
+          items: [
+            {icon: 'format_shapes', name:'to be – הווה', type: 'app', appType: 'mcq', listName: 'ENGLISH_TO_BE_PRESENT', questionIndex: 'question', resultIndex: 'answer', setItems: 5},
+            {icon: 'format_shapes', name:'to be – שלילה', type: 'app', appType: 'mcq', listName: 'ENGLISH_TO_BE_NEGATIVE', questionIndex: 'question', resultIndex: 'answer', setItems: 5},
+            {icon: 'format_shapes', name:'Find and match', type: 'app', appType: 'mcq', listName: 'ENGLISH_TO_BE_MATCH', questionIndex: 'question', resultIndex: 'answer', setItems: 5},
+            {icon: 'format_shapes', name:'Choose: am / is / are', type: 'app', appType: 'mcq', listName: 'ENGLISH_TO_BE_CHOOSE', questionIndex: 'question', resultIndex: 'answer', setItems: 5},
+            {icon: 'format_shapes', name:'Complete', type: 'app', appType: 'mcq', listName: 'ENGLISH_TO_BE_COMPLETE', questionIndex: 'question', resultIndex: 'answer', setItems: 5},
+          ]
+        },
+
+        {
           name: 'אוצר מילים לפי נושאים',
           type: 'menu',
           items: [

--- a/apps.js
+++ b/apps.js
@@ -32,19 +32,6 @@ apps =  {
         {icon: 'format_shapes', name:'מילות יחס', type: 'app', appType: 'mcq', listName: 'PREPOSITIONS', questionIndex: 'english_name', resultIndex:'hebrew', setItems: 3},
         {icon: 'format_shapes', name:'מילים חדשות', type: 'app', appType: 'mcq', listName: 'COLUMN_WORDS', questionIndex: 'english_name', resultIndex:'hebrew', setItems: 10},
         {icon: 'record_voice_over', name: 'אמור את שם האות', type: 'app', appType: 's2t', listName: 'ABC', questionIndex: 'englishUpperCase', resultIndex: 'englishUpperCase', setItems: 5, title: 'אמור בקול את שם האות'},
-
-        {
-          name: 'דקדוק - to be',
-          type: 'menu',
-          items: [
-            {icon: 'format_shapes', name:'to be – הווה', type: 'app', appType: 'mcq', listName: 'ENGLISH_TO_BE_PRESENT', questionIndex: 'question', resultIndex: 'answer', setItems: 5},
-            {icon: 'format_shapes', name:'to be – שלילה', type: 'app', appType: 'mcq', listName: 'ENGLISH_TO_BE_NEGATIVE', questionIndex: 'question', resultIndex: 'answer', setItems: 5},
-            {icon: 'format_shapes', name:'Find and match', type: 'app', appType: 'mcq', listName: 'ENGLISH_TO_BE_MATCH', questionIndex: 'question', resultIndex: 'answer', setItems: 5},
-            {icon: 'format_shapes', name:'Choose: am / is / are', type: 'app', appType: 'mcq', listName: 'ENGLISH_TO_BE_CHOOSE', questionIndex: 'question', resultIndex: 'answer', setItems: 5},
-            {icon: 'format_shapes', name:'Complete', type: 'app', appType: 'mcq', listName: 'ENGLISH_TO_BE_COMPLETE', questionIndex: 'question', resultIndex: 'answer', setItems: 5},
-          ]
-        },
-
         {
           name: 'אוצר מילים לפי נושאים',
           type: 'menu',
@@ -144,6 +131,18 @@ apps =  {
                 {icon: 'format_shapes', name:'הכל', type: 'app', appType: 'mcq', listName: 'ENGLISH_0_29_ALL', questionIndex: 'hebrew', resultIndex: 'english', setItems: 10},
               ]
             },
+         {
+          name: 'דקדוק - to be',
+          type: 'menu',
+          items: [
+            {icon: 'format_shapes', name:'to be – הווה', type: 'app', appType: 'mcq', listName: 'ENGLISH_TO_BE_PRESENT', questionIndex: 'question', resultIndex: 'answer', setItems: 5},
+            {icon: 'format_shapes', name:'to be – שלילה', type: 'app', appType: 'mcq', listName: 'ENGLISH_TO_BE_NEGATIVE', questionIndex: 'question', resultIndex: 'answer', setItems: 5},
+            {icon: 'format_shapes', name:'Find and match', type: 'app', appType: 'mcq', listName: 'ENGLISH_TO_BE_MATCH', questionIndex: 'question', resultIndex: 'answer', setItems: 5},
+            {icon: 'format_shapes', name:'Choose: am / is / are', type: 'app', appType: 'mcq', listName: 'ENGLISH_TO_BE_CHOOSE', questionIndex: 'question', resultIndex: 'answer', setItems: 5},
+            {icon: 'format_shapes', name:'Complete', type: 'app', appType: 'mcq', listName: 'ENGLISH_TO_BE_COMPLETE', questionIndex: 'question', resultIndex: 'answer', setItems: 5},
+          ]
+        },
+
           ]
         },
       ]

--- a/data.js
+++ b/data.js
@@ -6734,6 +6734,53 @@ ENGLISH_0_29_VERBS_AND_PEOPLE: [
   {"hebrew": {"type": "text", "value": "לנסות"}, "english": {"type": "text", "value": "Try"}, "english_name": {"type": "text_to_speech", "value": "Try"}}
 ],
 
+ENGLISH_TO_BE_PRESENT: [
+  {"question": {"type": "text", "value": "I"}, "answer": {"type": "text", "value": "am"}},
+  {"question": {"type": "text", "value": "You"}, "answer": {"type": "text", "value": "are"}},
+  {"question": {"type": "text", "value": "He"}, "answer": {"type": "text", "value": "is"}},
+  {"question": {"type": "text", "value": "She"}, "answer": {"type": "text", "value": "is"}},
+  {"question": {"type": "text", "value": "It"}, "answer": {"type": "text", "value": "is"}},
+  {"question": {"type": "text", "value": "We"}, "answer": {"type": "text", "value": "are"}},
+  {"question": {"type": "text", "value": "They"}, "answer": {"type": "text", "value": "are"}}
+],
+
+ENGLISH_TO_BE_NEGATIVE: [
+  {"question": {"type": "text", "value": "I ___ hungry"}, "answer": {"type": "text", "value": "am not"}},
+  {"question": {"type": "text", "value": "She ___ late"}, "answer": {"type": "text", "value": "is not"}},
+  {"question": {"type": "text", "value": "It ___ noisy"}, "answer": {"type": "text", "value": "is not"}},
+  {"question": {"type": "text", "value": "We ___ cold"}, "answer": {"type": "text", "value": "are not"}},
+  {"question": {"type": "text", "value": "You ___ sleepy"}, "answer": {"type": "text", "value": "are not"}},
+  {"question": {"type": "text", "value": "They ___ ready"}, "answer": {"type": "text", "value": "are not"}}
+],
+
+ENGLISH_TO_BE_MATCH: [
+  {"question": {"type": "text", "value": "She is fast"}, "answer": {"type": "text", "value": "👧"}},
+  {"question": {"type": "text", "value": "He is strong"}, "answer": {"type": "text", "value": "👦"}},
+  {"question": {"type": "text", "value": "It is very slow"}, "answer": {"type": "text", "value": "🐢"}},
+  {"question": {"type": "text", "value": "They are happy"}, "answer": {"type": "text", "value": "👧👦"}},
+  {"question": {"type": "text", "value": "The babies are small"}, "answer": {"type": "text", "value": "👶👶"}},
+  {"question": {"type": "text", "value": "The dog is playful"}, "answer": {"type": "text", "value": "🐶"}}
+],
+
+ENGLISH_TO_BE_CHOOSE: [
+  {"question": {"type": "text", "value": "I ___ early"}, "answer": {"type": "text", "value": "am"}},
+  {"question": {"type": "text", "value": "The cat ___ black"}, "answer": {"type": "text", "value": "is"}},
+  {"question": {"type": "text", "value": "You ___ funny"}, "answer": {"type": "text", "value": "are"}},
+  {"question": {"type": "text", "value": "We ___ in class"}, "answer": {"type": "text", "value": "are"}},
+  {"question": {"type": "text", "value": "She ___ kind"}, "answer": {"type": "text", "value": "is"}},
+  {"question": {"type": "text", "value": "The boys ___ loud"}, "answer": {"type": "text", "value": "are"}},
+  {"question": {"type": "text", "value": "It ___ cold"}, "answer": {"type": "text", "value": "is"}}
+],
+
+ENGLISH_TO_BE_COMPLETE: [
+  {"question": {"type": "text", "value": "I ___ at home"}, "answer": {"type": "text", "value": "am"}},
+  {"question": {"type": "text", "value": "My brother and I ___ tall"}, "answer": {"type": "text", "value": "are"}},
+  {"question": {"type": "text", "value": "You ___ my friend"}, "answer": {"type": "text", "value": "are"}},
+  {"question": {"type": "text", "value": "The cow ___ on the grass"}, "answer": {"type": "text", "value": "is"}},
+  {"question": {"type": "text", "value": "The teachers ___ here"}, "answer": {"type": "text", "value": "are"}},
+  {"question": {"type": "text", "value": "The apple ___ red"}, "answer": {"type": "text", "value": "is"}}
+],
+
 ENGLISH_0_28_ALL: [],
 
 ENGLISH_0_29_ALL: [],


### PR DESCRIPTION
### Motivation
- Provide a set of focused English "to be" exercises (present, negation, matching, choose, complete) for classroom/test preparation.

### Description
- Added new practice datasets to `data.js`: `ENGLISH_TO_BE_PRESENT`, `ENGLISH_TO_BE_NEGATIVE`, `ENGLISH_TO_BE_MATCH`, `ENGLISH_TO_BE_CHOOSE`, and `ENGLISH_TO_BE_COMPLETE` with example items for each activity. 
- Exposed a new English submenu `דקדוק - to be` in `apps.js` with entries that map the UI activities to the new lists and use `appType: 'mcq'` and `setItems: 5`.
- Kept existing data structures and list flattening logic intact and inserted the new lists alongside other English vocab lists.

### Testing
- Launched a simple HTTP server with `python -m http.server` which started successfully in the environment. 
- Attempted automated UI validation via Playwright to open the English menu and capture a screenshot, but the Playwright/browser runs timed out or crashed, so the UI check did not complete. 
- The patch was applied and changes were committed to the repository (`git commit` succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69763f7f9f9c832e81cbca6996d11318)