### PR TITLE
Fix display key selection for grammar lists

### DIFF
--- a/tester.js
+++ b/tester.js
@@ -1511,12 +1511,16 @@ var AppComponent = Vue.component('app',{
         this.score = getScore(this.currentAppId);
         this.progress = getProgress(this.currentAppId, 1);
         this.data = DATA[this.currentApp.listName];
-        displayNames = ["id", "name", "english_name", "englishUpperCase", 'letter'];
+        displayNames = ["id", "name", "english_name", "englishUpperCase", "letter", "question", "hebrew", "english", "answer"];
         for (let i = 0; i < displayNames.length; i++) {
             if(this.data[0].hasOwnProperty(displayNames[i])){
                 this.displayKey = displayNames[i];
                 break;
             }
+        }
+        if (!this.displayKey) {
+            const dataKeys = Object.keys(this.data[0] || {});
+            this.displayKey = dataKeys.length ? dataKeys[0] : null;
         }
 
         this.weights = getWeightsForKey(this.currentAppId, getSetItems(this.currentApp), getDataList(this.currentApp.listName));


### PR DESCRIPTION
### Motivation
- The app display view assumed a limited set of display keys (e.g. `name`, `english_name`) and failed for grammar lists that only include `question`/`answer`, causing those games to break. 
- The change aims to make the display key detection more robust so lists without a `name` can still be shown.

### Description
- Expanded the `displayNames` candidate list to include `"question"`, `"hebrew"`, `"english"`, and `"answer"` so grammar/QA lists are recognized. 
- Added a fallback that picks the first available property from the data item when no candidate keys match (`Object.keys(this.data[0])[0]`).
- Change applied to `tester.js` in the `created` hook of the `AppComponent` where `displayKey` is determined.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977157d2ca8832e94ef76132b4085fb)