### PR TITLE
Group colors and animals under new 'ציורים' submenu

### DIFF
--- a/apps.js
+++ b/apps.js
@@ -6,7 +6,14 @@ apps =  {
       name: 'אנגלית',
       type: 'menu',
       items: [
-        {icon: 'format_shapes', name:'צבעים', type: 'app', appType: 'mcq', listName: 'COLORS', questionIndex: 'english_name', resultIndex: 'emoji' },
+        {
+          name: 'ציורים',
+          type: 'menu',
+          items: [
+            {icon: 'format_shapes', name:'צבעים', type: 'app', appType: 'mcq', listName: 'COLORS', questionIndex: 'english_name', resultIndex: 'emoji' },
+            {icon: 'format_shapes', name:'חיות - אייקון', type: 'app', appType: 'mcq', listName: 'ANIMALS', questionIndex: 'english_name', resultIndex: 'emoji'},
+          ]
+        },
         {icon: 'format_shapes', name:'פעולות', type: 'app', appType: 'mcq', listName: 'VERBS', questionIndex: 'english_name', resultIndex: 'verb_hebrew'},
         {icon: 'format_shapes', name:'רגשות', type: 'app', appType: 'mcq', listName: 'FEELING', questionIndex: 'english_name', resultIndex: 'emoji'},
         {icon: 'format_shapes', name:'רגשות', type: 'app', appType: 'mcq', listName: 'FEELING', questionIndex: 'name', resultIndex: 'hebrew_english_name'},


### PR DESCRIPTION
### Motivation
- Replace the standalone English "צבעים" menu item with a grouped submenu so the colors and animals-emoji quizzes live together under a single "ציורים" entry.

### Description
- Updated `apps.js` to replace the top-level `צבעים` entry with a `ציורים` menu that contains two items: `צבעים` (COLORS, `resultIndex: 'emoji'`) and `חיות - אייקון` (ANIMALS, `resultIndex: 'emoji'`).
- This moves the animals-emoji quiz into the new submenu so the two related quiz types are grouped in the UI.
- Change is a configuration/menu-only update and does not modify quiz logic or list data.

### Testing
- Started a local server with `python -m http.server 4173` to serve `index.html` and the server started successfully. 
- Attempted an automated Playwright smoke screenshot to open the English menu and capture the new submenu, but the Playwright browser crashed with a SIGSEGV and the screenshot step failed. 
- No other automated tests were run; the change is a menu configuration update and was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977a1b4ecd0832eb067fcb081d75b50)