### PR TITLE
Add Hebrew numbers activity to Hebrew menu

### DIFF
--- a/apps.js
+++ b/apps.js
@@ -221,6 +221,7 @@ apps =  {
       type: 'menu',
       items: [
         {icon: 'format_size', name:'אותיות', type: 'app', appType: 'mcq', listName: 'hebrewAlphabet', questionIndex: 'letterName', resultIndex: 'letter'},
+        {icon: 'format_list_numbered', name:'מספרים', type: 'app', appType: 'mcq', listName: 'HEBREW_NUMBERS', questionIndex: 'numberName', resultIndex: 'number'},
         {icon: 'format_size', name:'אותיות עם ניקוד', type: 'app', appType: 'mcq', listName: 'HEBREW_LETTERS_WITH_NIKUD', questionIndex: 'letter', resultIndex: 'letter', questionType: 'speech'},
         {icon: 'format_size', name:'השם שלי', type: 'app', appType: 'mcq', listName: 'NAME', questionIndex: 'letterName', resultIndex: 'letter'},
       ]

--- a/data.js
+++ b/data.js
@@ -1821,6 +1821,20 @@ FAMILY: [
   }
 ],
 
+HEBREW_NUMBERS: [
+  {"number": {"type": "text", "value": "0"}, "numberName": {"type": "speech", "value": "אֶפֶס"}},
+  {"number": {"type": "text", "value": "1"}, "numberName": {"type": "speech", "value": "אֶחָד"}},
+  {"number": {"type": "text", "value": "2"}, "numberName": {"type": "speech", "value": "שְׁתַּיִם"}},
+  {"number": {"type": "text", "value": "3"}, "numberName": {"type": "speech", "value": "שָׁלוֹש"}},
+  {"number": {"type": "text", "value": "4"}, "numberName": {"type": "speech", "value": "אַרְבַּע"}},
+  {"number": {"type": "text", "value": "5"}, "numberName": {"type": "speech", "value": "חָמֵש"}},
+  {"number": {"type": "text", "value": "6"}, "numberName": {"type": "speech", "value": "שֵׁש"}},
+  {"number": {"type": "text", "value": "7"}, "numberName": {"type": "speech", "value": "שֶׁבַע"}},
+  {"number": {"type": "text", "value": "8"}, "numberName": {"type": "speech", "value": "שְׁמוֹנֶה"}},
+  {"number": {"type": "text", "value": "9"}, "numberName": {"type": "speech", "value": "תֵּשַׁע"}},
+  {"number": {"type": "text", "value": "10"}, "numberName": {"type": "speech", "value": "עֶשֶׂר"}}
+],
+
 
 NUMBERS: [
     {


### PR DESCRIPTION
### Motivation
- Add a Hebrew numbers practice to mirror the existing Hebrew letters activity so users can practice number names and digits.

### Description
- Added a new `HEBREW_NUMBERS` data list to `data.js` containing numbers `0`–`10` with spoken Hebrew names (`number` and `numberName`).
- Added a new menu item under the `עברית` menu in `apps.js` that uses `HEBREW_NUMBERS` with `questionIndex: numberName` and `resultIndex: number` for an MCQ activity.
- Updated files: `data.js` and `apps.js` and committed the changes.

### Testing
- Ran syntax checks with `node --check apps.js && node --check data.js` which succeeded.
- Launched a local server with `python3 -m http.server 4173` and executed an automated Playwright script to open the app, navigate to `עברית`, and capture a screenshot, which completed successfully.
- Verified the new `מספרים` menu item appears in the Hebrew menu and loads the MCQ activity using the new data list.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2e566eda0832e84a4f789c56c7b1a)