### PR TITLE
Add new 'משחק חדש - Chapter 4' menu and ENGLISH_NEW_CHAPTER4 vocabulary lists

### DIFF
--- a/apps.js
+++ b/apps.js
@@ -220,6 +220,34 @@ apps =  {
                 },
               ]
             },
+        {
+              name: 'משחק חדש - Chapter 4',
+              type: 'menu',
+              items: [
+                {
+                  name: 'אנגלית לעברית',
+                  type: 'menu',
+                  items: [
+                    {icon: 'format_shapes', name:'מילים כלליות', type: 'app', appType: 'mcq', listName: 'ENGLISH_NEW_CHAPTER4_GENERAL_WORDS', questionIndex: 'english_name', resultIndex: 'hebrew', setItems: 3},
+                    {icon: 'format_shapes', name:'אנשים ופעולות', type: 'app', appType: 'mcq', listName: 'ENGLISH_NEW_CHAPTER4_PEOPLE_AND_ACTIONS', questionIndex: 'english_name', resultIndex: 'hebrew', setItems: 3},
+                    {icon: 'format_shapes', name:'עונות ומזג אוויר', type: 'app', appType: 'mcq', listName: 'ENGLISH_NEW_CHAPTER4_SEASONS_AND_WEATHER', questionIndex: 'english_name', resultIndex: 'hebrew', setItems: 3},
+                    {icon: 'format_shapes', name:'משפטי מזג אוויר', type: 'app', appType: 'mcq', listName: 'ENGLISH_NEW_CHAPTER4_WEATHER_SENTENCES', questionIndex: 'english_name', resultIndex: 'hebrew', setItems: 3},
+                    {icon: 'format_shapes', name:'הכל', type: 'app', appType: 'mcq', listName: 'ENGLISH_NEW_CHAPTER4_ALL', questionIndex: 'english_name', resultIndex: 'hebrew', setItems: 10},
+                  ]
+                },
+                {
+                  name: 'עברית לאנגלית',
+                  type: 'menu',
+                  items: [
+                    {icon: 'format_shapes', name:'מילים כלליות', type: 'app', appType: 'mcq', listName: 'ENGLISH_NEW_CHAPTER4_GENERAL_WORDS', questionIndex: 'hebrew', resultIndex: 'english', setItems: 3},
+                    {icon: 'format_shapes', name:'אנשים ופעולות', type: 'app', appType: 'mcq', listName: 'ENGLISH_NEW_CHAPTER4_PEOPLE_AND_ACTIONS', questionIndex: 'hebrew', resultIndex: 'english', setItems: 3},
+                    {icon: 'format_shapes', name:'עונות ומזג אוויר', type: 'app', appType: 'mcq', listName: 'ENGLISH_NEW_CHAPTER4_SEASONS_AND_WEATHER', questionIndex: 'hebrew', resultIndex: 'english', setItems: 3},
+                    {icon: 'format_shapes', name:'משפטי מזג אוויר', type: 'app', appType: 'mcq', listName: 'ENGLISH_NEW_CHAPTER4_WEATHER_SENTENCES', questionIndex: 'hebrew', resultIndex: 'english', setItems: 3},
+                    {icon: 'format_shapes', name:'הכל', type: 'app', appType: 'mcq', listName: 'ENGLISH_NEW_CHAPTER4_ALL', questionIndex: 'hebrew', resultIndex: 'english', setItems: 10},
+                  ]
+                },
+              ]
+            },
       ]
     },
     {

--- a/data.js
+++ b/data.js
@@ -7108,11 +7108,67 @@ ENGLISH_NEW_GAME_PRONUNCIATION: [
   {"question": {"type": "text", "value": "סיומת /er/"}, "answer": {"type": "text", "value": "center"}}
 ],
 
+
+ENGLISH_NEW_CHAPTER4_GENERAL_WORDS: [
+  {"hebrew": {"type": "text", "value": "עיר"}, "english": {"type": "text", "value": "City"}, "english_name": {"type": "text_to_speech", "value": "City"}},
+  {"hebrew": {"type": "text", "value": "פנים"}, "english": {"type": "text", "value": "Face"}, "english_name": {"type": "text_to_speech", "value": "Face"}},
+  {"hebrew": {"type": "text", "value": "מיץ"}, "english": {"type": "text", "value": "Juice"}, "english_name": {"type": "text_to_speech", "value": "Juice"}},
+  {"hebrew": {"type": "text", "value": "עיפרון"}, "english": {"type": "text", "value": "Pencil"}, "english_name": {"type": "text_to_speech", "value": "Pencil"}},
+  {"hebrew": {"type": "text", "value": "מקום"}, "english": {"type": "text", "value": "Place"}, "english_name": {"type": "text_to_speech", "value": "Place"}},
+  {"hebrew": {"type": "text", "value": "משטרה"}, "english": {"type": "text", "value": "Police"}, "english_name": {"type": "text_to_speech", "value": "Police"}},
+  {"hebrew": {"type": "text", "value": "נחמד"}, "english": {"type": "text", "value": "Nice"}, "english_name": {"type": "text_to_speech", "value": "Nice"}},
+  {"hebrew": {"type": "text", "value": "תפוז"}, "english": {"type": "text", "value": "Orange"}, "english_name": {"type": "text_to_speech", "value": "Orange"}},
+  {"hebrew": {"type": "text", "value": "ירקות"}, "english": {"type": "text", "value": "Vegetables"}, "english_name": {"type": "text_to_speech", "value": "Vegetables"}},
+  {"hebrew": {"type": "text", "value": "זבל"}, "english": {"type": "text", "value": "Garbage"}, "english_name": {"type": "text_to_speech", "value": "Garbage"}}
+],
+
+ENGLISH_NEW_CHAPTER4_PEOPLE_AND_ACTIONS: [
+  {"hebrew": {"type": "text", "value": "לשנות"}, "english": {"type": "text", "value": "Change"}, "english_name": {"type": "text_to_speech", "value": "Change"}},
+  {"hebrew": {"type": "text", "value": "ענק"}, "english": {"type": "text", "value": "Giant"}, "english_name": {"type": "text_to_speech", "value": "Giant"}},
+  {"hebrew": {"type": "text", "value": "תינוק"}, "english": {"type": "text", "value": "Baby"}, "english_name": {"type": "text_to_speech", "value": "Baby"}},
+  {"hebrew": {"type": "text", "value": "לקנות"}, "english": {"type": "text", "value": "Buy"}, "english_name": {"type": "text_to_speech", "value": "Buy"}},
+  {"hebrew": {"type": "text", "value": "משפחה"}, "english": {"type": "text", "value": "Family"}, "english_name": {"type": "text_to_speech", "value": "Family"}},
+  {"hebrew": {"type": "text", "value": "לעוף"}, "english": {"type": "text", "value": "Fly"}, "english_name": {"type": "text_to_speech", "value": "Fly"}},
+  {"hebrew": {"type": "text", "value": "שמח"}, "english": {"type": "text", "value": "Happy"}, "english_name": {"type": "text_to_speech", "value": "Happy"}},
+  {"hebrew": {"type": "text", "value": "רעב"}, "english": {"type": "text", "value": "Hungry"}, "english_name": {"type": "text_to_speech", "value": "Hungry"}},
+  {"hebrew": {"type": "text", "value": "ספרייה"}, "english": {"type": "text", "value": "Library"}, "english_name": {"type": "text_to_speech", "value": "Library"}},
+  {"hebrew": {"type": "text", "value": "קוף"}, "english": {"type": "text", "value": "Monkey"}, "english_name": {"type": "text_to_speech", "value": "Monkey"}},
+  {"hebrew": {"type": "text", "value": "מסיבה"}, "english": {"type": "text", "value": "Party"}, "english_name": {"type": "text_to_speech", "value": "Party"}},
+  {"hebrew": {"type": "text", "value": "שמיים"}, "english": {"type": "text", "value": "Sky"}, "english_name": {"type": "text_to_speech", "value": "Sky"}},
+  {"hebrew": {"type": "text", "value": "צמא"}, "english": {"type": "text", "value": "Thirsty"}, "english_name": {"type": "text_to_speech", "value": "Thirsty"}}
+],
+
+ENGLISH_NEW_CHAPTER4_SEASONS_AND_WEATHER: [
+  {"hebrew": {"type": "text", "value": "חורף"}, "english": {"type": "text", "value": "Winter"}, "english_name": {"type": "text_to_speech", "value": "Winter"}},
+  {"hebrew": {"type": "text", "value": "אביב"}, "english": {"type": "text", "value": "Spring"}, "english_name": {"type": "text_to_speech", "value": "Spring"}},
+  {"hebrew": {"type": "text", "value": "קיץ"}, "english": {"type": "text", "value": "Summer"}, "english_name": {"type": "text_to_speech", "value": "Summer"}},
+  {"hebrew": {"type": "text", "value": "סתיו"}, "english": {"type": "text", "value": "Fall"}, "english_name": {"type": "text_to_speech", "value": "Fall"}},
+  {"hebrew": {"type": "text", "value": "עלים"}, "english": {"type": "text", "value": "Leaves"}, "english_name": {"type": "text_to_speech", "value": "Leaves"}},
+  {"hebrew": {"type": "text", "value": "מעונן"}, "english": {"type": "text", "value": "Cloudy"}, "english_name": {"type": "text_to_speech", "value": "Cloudy"}},
+  {"hebrew": {"type": "text", "value": "גשום"}, "english": {"type": "text", "value": "Rainy"}, "english_name": {"type": "text_to_speech", "value": "Rainy"}},
+  {"hebrew": {"type": "text", "value": "שלג"}, "english": {"type": "text", "value": "Snow"}, "english_name": {"type": "text_to_speech", "value": "Snow"}},
+  {"hebrew": {"type": "text", "value": "מושלג"}, "english": {"type": "text", "value": "Snowy"}, "english_name": {"type": "text_to_speech", "value": "Snowy"}},
+  {"hebrew": {"type": "text", "value": "שמשי"}, "english": {"type": "text", "value": "Sunny"}, "english_name": {"type": "text_to_speech", "value": "Sunny"}},
+  {"hebrew": {"type": "text", "value": "רוח"}, "english": {"type": "text", "value": "Wind"}, "english_name": {"type": "text_to_speech", "value": "Wind"}},
+  {"hebrew": {"type": "text", "value": "עם רוח"}, "english": {"type": "text", "value": "Windy"}, "english_name": {"type": "text_to_speech", "value": "Windy"}}
+],
+
+ENGLISH_NEW_CHAPTER4_WEATHER_SENTENCES: [
+  {"hebrew": {"type": "text", "value": "מה מזג האוויר היום?"}, "english": {"type": "text", "value": "What's the weather today?"}, "english_name": {"type": "text_to_speech", "value": "What's the weather today?"}},
+  {"hebrew": {"type": "text", "value": "שמשי היום."}, "english": {"type": "text", "value": "It is sunny today."}, "english_name": {"type": "text_to_speech", "value": "It is sunny today."}},
+  {"hebrew": {"type": "text", "value": "מעונן היום."}, "english": {"type": "text", "value": "It is cloudy today."}, "english_name": {"type": "text_to_speech", "value": "It is cloudy today."}},
+  {"hebrew": {"type": "text", "value": "גשום היום."}, "english": {"type": "text", "value": "It is rainy today."}, "english_name": {"type": "text_to_speech", "value": "It is rainy today."}},
+  {"hebrew": {"type": "text", "value": "מושלג היום."}, "english": {"type": "text", "value": "It is snowy today."}, "english_name": {"type": "text_to_speech", "value": "It is snowy today."}},
+  {"hebrew": {"type": "text", "value": "יש רוח היום."}, "english": {"type": "text", "value": "It is windy today."}, "english_name": {"type": "text_to_speech", "value": "It is windy today."}}
+],
+
 ENGLISH_0_28_ALL: [],
 
 ENGLISH_0_29_ALL: [],
 
 ENGLISH_CHAPTER4_ALL: [],
+
+ENGLISH_NEW_CHAPTER4_ALL: [],
 
 ENGLISH_VOCAB_ALL: [],
 
@@ -7166,6 +7222,15 @@ const ENGLISH_CHAPTER4_LISTS = [
     DATA.ENGLISH_CHAPTER4_OTHER_AND_LOCATION,
 ];
 DATA.ENGLISH_CHAPTER4_ALL = ENGLISH_CHAPTER4_LISTS.flat();
+
+const ENGLISH_NEW_CHAPTER4_LISTS = [
+    DATA.ENGLISH_NEW_CHAPTER4_GENERAL_WORDS,
+    DATA.ENGLISH_NEW_CHAPTER4_PEOPLE_AND_ACTIONS,
+    DATA.ENGLISH_NEW_CHAPTER4_SEASONS_AND_WEATHER,
+    DATA.ENGLISH_NEW_CHAPTER4_WEATHER_SENTENCES,
+];
+DATA.ENGLISH_NEW_CHAPTER4_ALL = ENGLISH_NEW_CHAPTER4_LISTS.flat();
+
 
 function filterABCByString(lettersStr, abcList) {
     const letterSet = new Set(lettersStr.split("")); // להאיץ את הבדיקה


### PR DESCRIPTION
### Motivation
- Introduce a new Chapter 4 game section with separate English↔Hebrew quiz tracks to expand vocabulary coverage. 
- Group related new word sets (general words, people/actions, seasons/weather, weather sentences) so they can be used in multiple MCQ apps. 
- Expose the new lists through the app menu so users can select the new chapter content from the UI.

### Description
- Added a new menu entry in `apps.js` named `משחק חדש - Chapter 4` with nested `אנגלית לעברית` and `עברית לאנגלית` submenus that reference the new datasets and set `appType: 'mcq'` and `setItems` values. 
- Added four new vocabulary lists in `data.js`: `ENGLISH_NEW_CHAPTER4_GENERAL_WORDS`, `ENGLISH_NEW_CHAPTER4_PEOPLE_AND_ACTIONS`, `ENGLISH_NEW_CHAPTER4_SEASONS_AND_WEATHER`, and `ENGLISH_NEW_CHAPTER4_WEATHER_SENTENCES`, each including `hebrew`, `english`, and `english_name` (`text_to_speech`) fields. 
- Created `ENGLISH_NEW_CHAPTER4_LISTS` and populated `DATA.ENGLISH_NEW_CHAPTER4_ALL` by flattening those lists for consolidated access. 
- Kept existing structures and helper usage intact (vocab items follow the same object shape as other lists and integrate with existing MCQ behavior).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a031d859644832eb2626ce03da90adb)