### PR TITLE
Add Factory Tycoon: a live idle-factory game with a swappable upgrade gate

### DIFF
--- a/apps.js
+++ b/apps.js
@@ -360,5 +360,12 @@ apps =  {
         {icon: 'sports_esports', name:'מבוך התיאורים', type: 'app', appType: 'treasure_maze', listName: 'BIG_VACATION_SIZES', questionIndex: 'english_name', resultIndex: 'picture', setItems: 1, title: 'הקשב למילה ובחר את הדלת הנכונה'},
       ]
     },
+    {
+      name: 'מפעל',
+      type: 'menu',
+      items: [
+        {icon: 'precision_manufacturing', name:'מפעל הצעצועים', type: 'app', appType: 'factory_tycoon', listName: 'FACTORY_UPGRADES', questionIndex: 'name', resultIndex: 'name', setItems: 4, title: 'בנו ושדרגו מפעל צעצועים חי'},
+      ]
+    },
   ]
 };

--- a/data.js
+++ b/data.js
@@ -7436,3 +7436,31 @@ function getUniqueElements(word) {
 
     return uniqueElements;
 }
+
+
+// Factory Tycoon (games/factory-tycoon.js) tech tree. Each item is one
+// confirmable upgrade; "machine"/"level"/"kind"/"cost" drive the simulation,
+// "name"/"detail" are shown by the confirmUpgrade() dialog. Kept in build
+// order (sawmill -> workshop -> packaging, then workers/conveyors/decor) so
+// each batch of `setItems` unlocks a coherent next step for the factory.
+DATA.FACTORY_UPGRADES = [
+    {name: {type: 'text', value: 'שדרוג המסור לרמה 2'}, detail: {type: 'text', value: 'להב מהיר יותר חותך קורות לעץ מהר יותר.'}, machine: 'sawmill', level: 2, kind: 'upgrade', cost: 50},
+    {name: {type: 'text', value: 'הנחת מסוע ראשון'}, detail: {type: 'text', value: 'מסוע נע יוביל קרשים אל תחנת העבודה הבאה.'}, machine: 'conveyor1', level: 1, kind: 'build', cost: 30},
+    {name: {type: 'text', value: 'גיוס עובד ראשון'}, detail: {type: 'text', value: 'זוג ידיים נוסף להעביר סחורה בין תחנות.'}, machine: 'worker1', level: 1, kind: 'hire', cost: 80},
+    {name: {type: 'text', value: 'בניית מגרסת הרכבה'}, detail: {type: 'text', value: 'תחנה חדשה שהופכת קרשים לחלקי צעצוע.'}, machine: 'workshop', level: 1, kind: 'build', cost: 120},
+
+    {name: {type: 'text', value: 'שדרוג המסור לרמה 3'}, detail: {type: 'text', value: 'עוד עוצמה, עוד קורות בדקה.'}, machine: 'sawmill', level: 3, kind: 'upgrade', cost: 140},
+    {name: {type: 'text', value: 'שדרוג מגרסת ההרכבה לרמה 2'}, detail: {type: 'text', value: 'זרועות הרכבה נוספות מייצרות מהר יותר.'}, machine: 'workshop', level: 2, kind: 'upgrade', cost: 160},
+    {name: {type: 'text', value: 'הנחת מסוע שני'}, detail: {type: 'text', value: 'קו הובלה שני מקצר את הדרך למחסן.'}, machine: 'conveyor2', level: 1, kind: 'build', cost: 90},
+    {name: {type: 'text', value: 'גיוס עובד שני'}, detail: {type: 'text', value: 'עוד עובד, פחות המתנה על הפס.'}, machine: 'worker2', level: 1, kind: 'hire', cost: 220},
+
+    {name: {type: 'text', value: 'בניית עמדת אריזה'}, detail: {type: 'text', value: 'תחנה סופית שאורזת צעצועים מוכנים למשלוח.'}, machine: 'packaging', level: 1, kind: 'build', cost: 260},
+    {name: {type: 'text', value: 'שדרוג עמדת האריזה לרמה 2'}, detail: {type: 'text', value: 'קופסאות נסגרות ונשלחות מהר יותר.'}, machine: 'packaging', level: 2, kind: 'upgrade', cost: 200},
+    {name: {type: 'text', value: 'שדרוג מגרסת ההרכבה לרמה 3'}, detail: {type: 'text', value: 'תחנת ההרכבה המהירה ביותר עד כה.'}, machine: 'workshop', level: 3, kind: 'upgrade', cost: 240},
+    {name: {type: 'text', value: 'בניית מחסן אחסון'}, detail: {type: 'text', value: 'מקום לאחסן תוצרת בזמן שהפס עובד.'}, machine: 'storage', level: 1, kind: 'build', cost: 150},
+
+    {name: {type: 'text', value: 'שדרוג המסור לרמה 4'}, detail: {type: 'text', value: 'המסור המהיר ביותר במפעל.'}, machine: 'sawmill', level: 4, kind: 'upgrade', cost: 320},
+    {name: {type: 'text', value: 'גיוס עובד שלישי'}, detail: {type: 'text', value: 'צוות שלם עכשיו רץ בין כל התחנות.'}, machine: 'worker3', level: 1, kind: 'hire', cost: 380},
+    {name: {type: 'text', value: 'תלייה שלט מפעל'}, detail: {type: 'text', value: 'שלט מואר עם שם המפעל, לגאווה.'}, machine: 'sign', level: 1, kind: 'decorate', cost: 100},
+    {name: {type: 'text', value: 'שדרוג עמדת האריזה לרמה 3'}, detail: {type: 'text', value: 'קו הייצור השלם רץ במהירות המרבית.'}, machine: 'packaging', level: 3, kind: 'upgrade', cost: 420},
+];

--- a/games/factory-tycoon.css
+++ b/games/factory-tycoon.css
@@ -1,0 +1,509 @@
+/* Factory Tycoon — live idle factory scene. Full-screen overlay like
+   games/water-pipeline.css; percentages inside .ft-track are physical
+   (left/top), not logical, so the scene layout stays identical under the
+   page's RTL direction while all text/controls still read RTL. */
+
+.ft-game {
+    position: fixed;
+    inset: 0;
+    width: 100dvw;
+    height: 100dvh;
+    overflow: hidden;
+    z-index: 1100;
+    isolation: isolate;
+    color: var(--ft-panel-ink);
+    background: radial-gradient(circle at 50% -10%, var(--ft-sky-a), var(--ft-sky-b) 65%);
+    font-family: "Segoe UI", Arial, sans-serif;
+    user-select: none;
+    touch-action: manipulation;
+}
+
+.ft-game *, .ft-game *::before, .ft-game *::after { box-sizing: border-box; }
+.ft-game button { font: inherit; }
+
+.ft-sky {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to bottom, transparent 55%, rgba(0, 0, 0, 0.08) 100%);
+    pointer-events: none;
+}
+
+.ft-vignette {
+    position: absolute;
+    inset: 0;
+    z-index: 5;
+    pointer-events: none;
+    background: radial-gradient(ellipse at center, transparent 60%, rgba(0, 0, 0, 0.22) 100%);
+}
+
+/* ---------- HUD ---------- */
+
+.ft-hud {
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    z-index: 20;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    background: linear-gradient(to bottom, rgba(0, 0, 0, 0.28), transparent);
+}
+
+.ft-round-btn {
+    width: 40px;
+    height: 40px;
+    flex: 0 0 auto;
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    border-radius: 50%;
+    background: var(--ft-panel);
+    color: var(--ft-panel-ink);
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.ft-round-btn:hover { transform: translateY(-1px) scale(1.04); }
+.ft-round-btn:active { transform: translateY(0) scale(0.96); }
+.ft-round-btn:focus-visible { outline: 3px solid var(--ft-accent); outline-offset: 2px; }
+
+.ft-hud-center {
+    flex: 1;
+    min-width: 0;
+    text-align: center;
+}
+
+.ft-scene-name {
+    font-weight: 800;
+    font-size: clamp(14px, 2.6vw, 19px);
+    text-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+    color: #fff;
+}
+
+.ft-learning-gauge {
+    position: relative;
+    margin: 4px auto 0;
+    width: min(220px, 60%);
+    height: 8px;
+    border-radius: 5px;
+    background: rgba(0, 0, 0, 0.35);
+    overflow: hidden;
+}
+.ft-learning-gauge i {
+    display: block;
+    height: 100%;
+    background: linear-gradient(90deg, var(--ft-accent), var(--ft-glow));
+    transition: width 0.4s ease;
+}
+.ft-learning-gauge b {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 9px;
+    font-weight: 700;
+    color: #fff;
+    direction: ltr;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
+}
+
+.ft-money {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    background: var(--ft-panel);
+    color: var(--ft-panel-ink);
+    padding: 6px 12px;
+    border-radius: 20px;
+    font-weight: 800;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
+    direction: ltr;
+}
+
+.ft-coin-icon, .ft-coin-icon-sm { width: 22px; height: 22px; }
+.ft-coin-icon-sm { width: 18px; height: 18px; }
+.ft-coin-body { fill: #f9c440; stroke: #c8860a; stroke-width: 1.4; }
+.ft-coin-core { fill: #ffe08a; }
+
+.ft-money-value {
+    font-size: 16px;
+    transition: transform 0.2s ease;
+}
+.ft-money-pop { transform: scale(1.28); color: #d68a00; }
+
+/* ---------- Scene / camera ---------- */
+
+.ft-viewport {
+    position: absolute;
+    top: 58px;
+    bottom: 54px;
+    left: 0;
+    right: 0;
+    overflow: hidden;
+    touch-action: none;
+    cursor: grab;
+}
+.ft-viewport:active { cursor: grabbing; }
+
+.ft-camera {
+    position: absolute;
+    inset: 0;
+    transition: transform 0.25s cubic-bezier(0.2, 0.8, 0.2, 1);
+    will-change: transform;
+}
+
+.ft-track {
+    position: absolute;
+    inset: 0;
+}
+
+.ft-ground {
+    position: absolute;
+    left: 0; right: 0; bottom: 0;
+    height: 34%;
+    background: linear-gradient(to bottom, var(--ft-tertiary), var(--ft-secondary));
+    opacity: 0.55;
+}
+
+.ft-path-line {
+    position: absolute;
+    top: 68%;
+    height: 10px;
+    border-radius: 6px;
+    background: rgba(0, 0, 0, 0.18);
+    transform: translateY(-50%);
+}
+
+.ft-belt {
+    position: absolute;
+    height: 16px;
+    border-radius: 8px;
+    transform: translateY(-50%);
+    background:
+        repeating-linear-gradient(-45deg,
+            rgba(255, 255, 255, 0.22) 0 8px,
+            rgba(0, 0, 0, 0.18) 8px 16px);
+    background-size: 22px 100%;
+    border: 2px solid rgba(0, 0, 0, 0.3);
+    animation: ft-belt-scroll 0.9s linear infinite;
+}
+.ft-reduced .ft-belt { animation: none; }
+
+@keyframes ft-belt-scroll {
+    from { background-position: 0 0; }
+    to { background-position: -22px 0; }
+}
+
+/* ---------- Machines ---------- */
+
+.ft-machine, .ft-sign, .ft-storage, .ft-ship, .ft-worker, .ft-resource, .ft-coin-particle, .ft-badge {
+    position: absolute;
+    transform: translate(-50%, -60%);
+}
+
+.ft-machine svg { display: block; width: clamp(64px, 9.5vw, 118px); height: auto; overflow: visible; }
+.ft-ship svg { width: clamp(60px, 8.5vw, 104px); height: auto; }
+.ft-storage svg { width: clamp(46px, 6vw, 76px); height: auto; }
+.ft-sign svg { width: clamp(120px, 16vw, 220px); height: auto; }
+
+.ft-body { fill: var(--ft-secondary); stroke: var(--ft-ink); stroke-opacity: 0.35; stroke-width: 2; }
+.ft-hopper, .ft-slot, .ft-box { fill: var(--ft-tertiary); }
+
+.ft-blade-ring { fill: var(--ft-accent); stroke: var(--ft-ink); stroke-opacity: 0.3; stroke-width: 2; }
+.ft-blade-tooth { fill: var(--ft-primary); }
+.ft-blade-hub { fill: var(--ft-ink); fill-opacity: 0.55; }
+.ft-blade-group { transform-origin: 76px 54px; }
+.ft-blade-group.ft-spin { animation: ft-spin 0.5s linear infinite; }
+.ft-reduced .ft-blade-group.ft-spin { animation-duration: 1.4s; }
+
+@keyframes ft-spin { to { transform: rotate(360deg); } }
+
+.ft-chimney { fill: var(--ft-ink); fill-opacity: 0.4; }
+.ft-level-pip { fill: var(--ft-glow); }
+
+.ft-smoke-wrap { position: absolute; top: -6px; left: 12%; pointer-events: none; }
+.ft-smoke {
+    position: absolute;
+    width: 10px; height: 10px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.6);
+    animation: ft-smoke-rise 2.6s ease-out infinite;
+}
+.ft-smoke-1 { animation-delay: 0s; }
+.ft-smoke-2 { animation-delay: 0.9s; left: 4px; }
+.ft-smoke-3 { animation-delay: 1.8s; left: -4px; }
+.ft-reduced .ft-smoke { animation: none; opacity: 0.35; }
+
+@keyframes ft-smoke-rise {
+    0% { transform: translate(0, 0) scale(0.6); opacity: 0.55; }
+    100% { transform: translate(6px, -34px) scale(1.5); opacity: 0; }
+}
+
+.ft-arm-group { transform-origin: 60px 14px; }
+.ft-arm-post { fill: var(--ft-ink); fill-opacity: 0.5; }
+.ft-arm-hand { fill: var(--ft-accent); }
+.ft-arm-group.ft-swing { animation: ft-arm-swing 0.42s ease-in-out; }
+.ft-reduced .ft-arm-group.ft-swing { animation-duration: 0.15s; }
+
+@keyframes ft-arm-swing {
+    0%, 100% { transform: rotate(0deg); }
+    50% { transform: rotate(-26deg); }
+}
+
+.ft-flap { fill: var(--ft-tertiary); stroke: var(--ft-ink); stroke-opacity: 0.3; transform-origin: 60px 58px; transition: transform 0.2s ease; }
+.ft-flap-l { transform: rotate(0deg); }
+.ft-flap-r { transform: rotate(0deg); }
+.ft-flap.ft-flap-open.ft-flap-l { transform: rotate(-38deg); }
+.ft-flap.ft-flap-open.ft-flap-r { transform: rotate(38deg); }
+
+.ft-truck-body, .ft-truck-cab { fill: var(--ft-secondary); stroke: var(--ft-ink); stroke-opacity: 0.3; stroke-width: 2; }
+.ft-wheel { fill: var(--ft-ink); fill-opacity: 0.6; }
+
+.ft-sign-plate { fill: var(--ft-panel); stroke: var(--ft-accent); stroke-width: 2; }
+.ft-sign-text { fill: var(--ft-panel-ink); font-size: 13px; font-weight: 800; }
+
+.ft-storage-body { fill: var(--ft-secondary); stroke: var(--ft-ink); stroke-opacity: 0.3; stroke-width: 2; }
+.ft-storage-cap { fill: var(--ft-tertiary); }
+.ft-storage-band { fill: var(--ft-accent); }
+
+/* ---------- Workers ---------- */
+
+.ft-worker { top: 88%; }
+.ft-worker svg { width: clamp(24px, 3.6vw, 40px); height: auto; }
+.ft-worker-head { fill: var(--ft-glow); }
+.ft-worker-body { fill: var(--ft-primary); }
+.ft-worker-leg { fill: var(--ft-ink); fill-opacity: 0.55; transform-origin: top center; }
+
+.ft-worker-walk { animation: ft-worker-path 6.5s ease-in-out infinite; }
+.ft-worker-2.ft-worker-walk { animation-duration: 7.4s; animation-delay: -1.5s; }
+.ft-worker-3.ft-worker-walk { animation-duration: 8.1s; animation-delay: -3.2s; }
+
+@keyframes ft-worker-path {
+    0%, 100% { left: 88%; }
+    50% { left: 22%; }
+}
+
+.ft-worker-walk .ft-worker-leg-a { animation: ft-leg-swing 0.5s ease-in-out infinite; }
+.ft-worker-walk .ft-worker-leg-b { animation: ft-leg-swing 0.5s ease-in-out infinite reverse; }
+
+@keyframes ft-leg-swing {
+    0%, 100% { transform: rotate(14deg); }
+    50% { transform: rotate(-14deg); }
+}
+
+/* ---------- Resources & coins ---------- */
+
+.ft-resource { top: 58%; z-index: 6; transition: left 0.05s linear, top 0.05s linear; }
+.ft-resource svg { width: 22px; height: 22px; filter: drop-shadow(0 3px 3px rgba(0, 0, 0, 0.35)); }
+.ft-resource-shape { fill: var(--ft-resource); stroke: rgba(0, 0, 0, 0.35); stroke-width: 1.5; }
+.ft-resource-processed-a .ft-resource-shape { fill: var(--ft-accent); }
+.ft-resource-processed-b .ft-resource-shape { fill: var(--ft-glow); }
+
+.ft-coin-particle { z-index: 10; transition: left 0.05s linear, top 0.05s linear, opacity 0.05s linear; }
+.ft-coin-particle svg { width: 16px; height: 16px; }
+
+/* ---------- Upgrade badges ---------- */
+
+.ft-badge {
+    z-index: 15;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    border: 2px solid rgba(255, 255, 255, 0.7);
+    background: linear-gradient(180deg, #ffe27a, #f5a623);
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35), 0 0 0 0 rgba(255, 213, 79, 0.7);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.ft-badge-icon { width: 22px; height: 22px; fill: #7a4a00; }
+
+.ft-badge-ready { animation: ft-badge-pulse 1.6s ease-in-out infinite; }
+.ft-reduced .ft-badge-ready { animation: none; }
+
+@keyframes ft-badge-pulse {
+    0%, 100% { box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35), 0 0 0 0 rgba(255, 213, 79, 0.55); transform: translate(-50%, -60%) scale(1); }
+    50% { box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35), 0 0 0 10px rgba(255, 213, 79, 0); transform: translate(-50%, -60%) scale(1.08); }
+}
+
+.ft-badge-saving {
+    background: linear-gradient(180deg, #cfd8dc, #90a4ae);
+    cursor: default;
+    opacity: 0.9;
+}
+.ft-badge-saving .ft-badge-icon { fill: #37474f; }
+
+.ft-badge-cost {
+    position: absolute;
+    bottom: -16px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 10px;
+    font-weight: 800;
+    background: rgba(0, 0, 0, 0.65);
+    color: #fff;
+    padding: 1px 6px;
+    border-radius: 8px;
+    direction: ltr;
+    white-space: nowrap;
+}
+
+/* ---------- Zoom controls ---------- */
+
+.ft-zoom {
+    position: absolute;
+    right: 12px;
+    bottom: 62px;
+    z-index: 20;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.ft-zoom-btn { font-size: 20px; font-weight: 700; }
+
+/* ---------- Footer: score + progress ---------- */
+
+.ft-score-row {
+    position: absolute;
+    left: 12px;
+    bottom: 8px;
+    z-index: 20;
+}
+.ft-score {
+    background: var(--ft-panel);
+    color: var(--ft-panel-ink);
+    padding: 3px 10px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 700;
+    direction: ltr;
+}
+
+.ft-game .progress-container {
+    position: absolute;
+    left: 90px;
+    right: 90px;
+    bottom: 8px;
+    height: 14px;
+    z-index: 20;
+    box-shadow: none;
+}
+.ft-game .progress-bar { transition: width 0.5s ease-in-out; }
+.ft-game p { display: none; } /* progress-bar's own text label — HUD gauge already shows it */
+
+/* ---------- Accessibility ---------- */
+
+.ft-sr-live {
+    position: absolute;
+    width: 1px; height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+}
+
+/* ---------- Confirm dialog — the sole gate for every upgrade ---------- */
+
+.ft-modal-scrim {
+    position: absolute;
+    inset: 0;
+    z-index: 40;
+    background: rgba(4, 6, 12, 0.62);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    animation: ft-fade-in 0.18s ease;
+}
+.ft-reduced .ft-modal-scrim { animation: none; }
+
+@keyframes ft-fade-in { from { opacity: 0; } to { opacity: 1; } }
+
+.ft-modal {
+    width: min(360px, 100%);
+    background: var(--ft-panel);
+    color: var(--ft-panel-ink);
+    border-radius: 18px;
+    padding: 22px 20px 18px;
+    text-align: center;
+    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.45);
+    animation: ft-modal-in 0.22s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.ft-reduced .ft-modal { animation: ft-fade-in 0.12s ease; }
+
+@keyframes ft-modal-in {
+    from { transform: translateY(14px) scale(0.94); opacity: 0; }
+    to { transform: translateY(0) scale(1); opacity: 1; }
+}
+
+.ft-modal-icon {
+    width: 52px; height: 52px;
+    margin: 0 auto 8px;
+    border-radius: 50%;
+    background: linear-gradient(180deg, #ffe27a, #f5a623);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.ft-modal-icon svg { width: 28px; height: 28px; fill: #7a4a00; }
+
+.ft-modal-title { font-size: 19px; font-weight: 800; margin: 0 0 6px; }
+.ft-modal-detail { font-size: 14px; opacity: 0.8; margin: 0 0 12px; line-height: 1.4; }
+
+.ft-modal-cost {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: rgba(0, 0, 0, 0.08);
+    padding: 4px 12px;
+    border-radius: 14px;
+    font-weight: 800;
+    margin-bottom: 16px;
+    direction: ltr;
+}
+
+.ft-modal-actions { display: flex; gap: 10px; }
+.ft-modal-btn {
+    flex: 1;
+    padding: 12px 8px;
+    border-radius: 12px;
+    border: none;
+    font-size: 15px;
+    font-weight: 800;
+    cursor: pointer;
+    transition: transform 0.12s ease;
+}
+.ft-modal-btn:active { transform: scale(0.96); }
+.ft-modal-btn:focus-visible { outline: 3px solid var(--ft-accent); outline-offset: 2px; }
+.ft-modal-cancel { background: rgba(0, 0, 0, 0.08); color: var(--ft-panel-ink); }
+.ft-modal-confirm { background: linear-gradient(180deg, #6fe08a, #2fae55); color: #063613; }
+
+/* ---------- Dark themes (space / dark / code) ---------- */
+
+.ft-dark .ft-money, .ft-dark .ft-score, .ft-dark .ft-round-btn { background: var(--ft-panel); }
+
+/* ---------- Responsive ---------- */
+
+@media (orientation: portrait) {
+    .ft-viewport { top: 76px; bottom: 60px; }
+    .ft-scene-name { font-size: 13px; }
+    .ft-machine svg { width: clamp(52px, 15vw, 84px); }
+    .ft-sign svg { width: clamp(100px, 30vw, 170px); }
+}
+
+@media (max-height: 420px) {
+    .ft-hud { padding: 4px 8px; }
+    .ft-viewport { top: 46px; bottom: 38px; }
+    .ft-zoom { bottom: 44px; }
+    .ft-modal { padding: 16px 16px 12px; }
+}
+
+@media (max-width: 420px) {
+    .ft-money { padding: 5px 9px; font-size: 13px; }
+    .ft-money-value { font-size: 14px; }
+}
+
+.ft-game:fullscreen { background: var(--ft-bg); }
+.ft-game:-webkit-full-screen { background: var(--ft-bg); }

--- a/games/factory-tycoon.js
+++ b/games/factory-tycoon.js
@@ -1,0 +1,690 @@
+(function (global) {
+    'use strict';
+
+    // ---------------------------------------------------------------------
+    // Configuration: the tech tree lives in DATA.FACTORY_UPGRADES (data.js).
+    // Each purchased item bumps one "machine" key to a level; the factory's
+    // entire visual state is derived from that, not stored separately, so it
+    // always matches what the learning engine actually unlocked.
+    // ---------------------------------------------------------------------
+
+    const FT_DEFAULT_MACHINES = {
+        sawmill: 1, workshop: 0, packaging: 0,
+        conveyor1: 0, conveyor2: 0,
+        worker1: 0, worker2: 0, worker3: 0,
+        storage: 0, sign: 0,
+    };
+    const FT_KNOWN_MACHINES = Object.keys(FT_DEFAULT_MACHINES);
+    const FT_KINDS = ['upgrade', 'build', 'hire', 'decorate'];
+
+    const FT_ANCHORS = {
+        sawmill: {x: 86, y: 58},
+        workshop: {x: 58, y: 58},
+        packaging: {x: 30, y: 58},
+        ship: {x: 9, y: 62},
+        conveyor1: {x: 72, y: 68},
+        conveyor2: {x: 44, y: 68},
+        worker1: {x: 95, y: 88},
+        worker2: {x: 95, y: 88},
+        worker3: {x: 95, y: 88},
+        storage: {x: 17, y: 24},
+        sign: {x: 70, y: 10},
+    };
+
+    const FT_THEME_MOTIFS = {
+        base: {sceneName: 'מפעל הצעצועים', resource: '#c9843f', glow: '#ffcf7a'},
+        soldiers: {sceneName: 'מפעל האספקה', resource: '#8f9a5e', glow: '#ffd700'},
+        unicorn: {sceneName: 'מפעל הקסמים', resource: '#ef7fce', glow: '#ffe37a'},
+        space: {sceneName: 'תחנת ההרכבה החללית', resource: '#4fb8ff', glow: '#ffd700'},
+        dark: {sceneName: 'היציקה האפלה', resource: '#b58cf0', glow: '#7ee0c4'},
+        code: {sceneName: 'חוות השרתים', resource: '#39ff14', glow: '#00ff41'},
+    };
+
+    const FT_DARK_KEYS = ['space', 'dark', 'code'];
+
+    function validateFactoryUpgrades(list) {
+        const errors = [];
+        if (!Array.isArray(list) || !list.length) {
+            return ['factory upgrade list must be a non-empty array'];
+        }
+        list.forEach((item, index) => {
+            if (!item || !item.name || typeof item.name.value !== 'string' || !item.name.value.trim()) {
+                errors.push(`item ${index} needs a name.value`);
+            }
+            if (!FT_KNOWN_MACHINES.includes(item && item.machine)) {
+                errors.push(`item ${index} has unknown machine "${item && item.machine}"`);
+            }
+            if (!FT_KINDS.includes(item && item.kind)) {
+                errors.push(`item ${index} has unknown kind "${item && item.kind}"`);
+            }
+            if (!(Number(item && item.level) > 0)) {
+                errors.push(`item ${index} needs a positive level`);
+            }
+            if (!(Number(item && item.cost) > 0)) {
+                errors.push(`item ${index} needs a positive cost`);
+            }
+        });
+        return errors;
+    }
+
+    // Pure: visual/economic state is always rebuilt from the permanent
+    // "purchased" record, never from the learning engine's weights — weights
+    // get reset to 5 for spaced-repetition replay once a batch is mastered,
+    // which must not un-build machines the player already earned.
+    function deriveFactoryState(list, purchasedIndices) {
+        const machines = Object.assign({}, FT_DEFAULT_MACHINES);
+        (purchasedIndices || []).forEach(index => {
+            const item = list[index];
+            if (!item || !item.machine) return;
+            machines[item.machine] = Math.max(machines[item.machine] || 0, Number(item.level) || 1);
+        });
+        const workersHired = ['worker1', 'worker2', 'worker3'].filter(key => machines[key] > 0).length;
+        return {
+            machines: machines,
+            workersHired: workersHired,
+            conveyor1: machines.conveyor1 > 0,
+            conveyor2: machines.conveyor2 > 0,
+            storageBuilt: machines.storage > 0,
+            signBuilt: machines.sign > 0,
+            workshopBuilt: machines.workshop > 0,
+            packagingBuilt: machines.packaging > 0,
+            sawmillLevel: machines.sawmill,
+            workshopLevel: machines.workshop,
+            packagingLevel: machines.packaging,
+        };
+    }
+
+    function ftHexAlpha(hex, alpha) {
+        if (!/^#[0-9a-f]{6}$/i.test(hex || '')) return hex;
+        const value = parseInt(hex.slice(1), 16);
+        return `rgba(${(value >> 16) & 255}, ${(value >> 8) & 255}, ${value & 255}, ${alpha})`;
+    }
+
+    function resolveFactoryTheme() {
+        const requested = typeof getLocalStorage === 'function' ? getLocalStorage('theme', 'base') : 'base';
+        const key = FT_THEME_MOTIFS[requested] && typeof themeOptions !== 'undefined' && themeOptions[requested]
+            ? requested : 'base';
+        const palette = typeof themeOptions !== 'undefined' && themeOptions[key]
+            ? themeOptions[key].colors
+            : {primary: '#006064', secondary: '#78909c', tertiary: '#B0E0E6', accent: '#C0C0C0', background: '#F5F5F5', text: '#000000'};
+        const motif = FT_THEME_MOTIFS[key];
+        const dark = FT_DARK_KEYS.indexOf(key) !== -1;
+        return {
+            key: key,
+            motif: motif,
+            dark: dark,
+            css: {
+                '--ft-primary': palette.primary,
+                '--ft-secondary': palette.secondary,
+                '--ft-tertiary': palette.tertiary,
+                '--ft-accent': palette.accent,
+                '--ft-bg': palette.background,
+                '--ft-ink': palette.text,
+                '--ft-resource': motif.resource,
+                '--ft-glow': motif.glow,
+                '--ft-panel': dark ? 'rgba(12, 16, 26, 0.93)' : 'rgba(255, 255, 255, 0.95)',
+                '--ft-panel-ink': dark ? '#f3f3f3' : '#1c1c1c',
+                '--ft-sky-a': dark ? ftHexAlpha(palette.primary, 0.9) : ftHexAlpha(palette.tertiary, 0.55),
+                '--ft-sky-b': dark ? '#05070c' : palette.background,
+            },
+        };
+    }
+
+    // Economy tuning (kept as named constants for easy rebalancing).
+    const FT_BASE_VALUE = 6;
+    const FT_WORKSHOP_BONUS = level => 3 + level * 2;
+    const FT_PACKAGING_BONUS = level => 5 + level * 3;
+    const FT_SAWMILL_INTERVAL = level => Math.max(650, 2400 - (level - 1) * 500);
+    const FT_LEG_DURATION = 1050;
+    const FT_PROCESS_PAUSE = 420;
+    const FT_MAX_ITEMS = 7;
+
+    function createFactoryTycoonComponent(BaseGameComponent) {
+        return Vue.component('factory-tycoon', Vue.extend({
+            extends: BaseGameComponent,
+
+            template: `
+            <div ref="root" class="ft-game" :class="['ft-theme-' + ftTheme.key, {'ft-reduced': reducedMotion, 'ft-dark': ftTheme.dark}]" :style="ftTheme.css" dir="rtl">
+              <div class="ft-sky" aria-hidden="true"></div>
+              <div class="ft-vignette" aria-hidden="true"></div>
+
+              <header class="ft-hud">
+                <button class="ft-round-btn" type="button" @click="exitGame" aria-label="יציאה">←</button>
+                <div class="ft-hud-center">
+                  <div class="ft-scene-name">{{ ftTheme.motif.sceneName }}</div>
+                  <div class="ft-learning-gauge" v-if="progress">
+                    <i :style="{width: learningPercent + '%'}"></i>
+                    <b>{{ progress.progress }} / {{ progress.total }}</b>
+                  </div>
+                </div>
+                <div class="ft-money" aria-live="off">
+                  <svg class="ft-coin-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <circle cx="12" cy="12" r="10" class="ft-coin-body"></circle>
+                    <circle cx="12" cy="12" r="6.4" class="ft-coin-core"></circle>
+                  </svg>
+                  <span class="ft-money-value" :class="{'ft-money-pop': moneyPop}">{{ displayMoney }}</span>
+                </div>
+                <button class="ft-round-btn" type="button" @click="toggleFullscreen" aria-label="מסך מלא">⛶</button>
+              </header>
+
+              <div class="ft-viewport" ref="viewport"
+                   @pointerdown="startPan" @pointermove="movePan" @pointerup="endPan" @pointerleave="endPan" @pointercancel="endPan">
+                <div class="ft-camera" :style="cameraStyle">
+                  <div class="ft-track">
+
+                    <div class="ft-ground" aria-hidden="true"></div>
+
+                    <div v-if="derived.signBuilt" class="ft-sign" :style="anchorStyle('sign')" aria-hidden="true">
+                      <svg viewBox="0 0 140 44">
+                        <rect x="2" y="2" width="136" height="36" rx="8" class="ft-sign-plate"></rect>
+                        <text x="70" y="26" text-anchor="middle" class="ft-sign-text">{{ ftTheme.motif.sceneName }}</text>
+                      </svg>
+                    </div>
+
+                    <div v-if="derived.storageBuilt" class="ft-storage" :style="anchorStyle('storage')" aria-hidden="true">
+                      <svg viewBox="0 0 80 100">
+                        <rect x="10" y="20" width="60" height="70" rx="10" class="ft-storage-body"></rect>
+                        <ellipse cx="40" cy="20" rx="30" ry="10" class="ft-storage-cap"></ellipse>
+                        <rect x="18" y="55" width="44" height="8" rx="3" class="ft-storage-band"></rect>
+                      </svg>
+                    </div>
+
+                    <div class="ft-belt" v-if="derived.conveyor1" :style="beltStyle('conveyor1')" aria-hidden="true"></div>
+                    <div class="ft-belt" v-if="derived.conveyor2" :style="beltStyle('conveyor2')" aria-hidden="true"></div>
+                    <div class="ft-path-line" :style="pathLineStyle()" aria-hidden="true"></div>
+
+                    <div class="ft-machine ft-machine-sawmill" :class="'ft-lvl-' + derived.sawmillLevel" :style="anchorStyle('sawmill')" aria-hidden="true">
+                      <svg viewBox="0 0 120 120">
+                        <rect x="8" y="52" width="104" height="56" rx="12" class="ft-body"></rect>
+                        <rect x="26" y="30" width="26" height="26" rx="4" class="ft-hopper"></rect>
+                        <g class="ft-blade-group" :class="{'ft-spin': ftActive.sawmill}">
+                          <circle cx="76" cy="54" r="24" class="ft-blade-ring"></circle>
+                          <g class="ft-blade-teeth">
+                            <polygon v-for="n in 8" :key="n" :points="bladeTooth(n)" class="ft-blade-tooth"></polygon>
+                          </g>
+                          <circle cx="76" cy="54" r="7" class="ft-blade-hub"></circle>
+                        </g>
+                        <rect v-if="derived.sawmillLevel > 2" x="14" y="16" width="10" height="20" rx="3" class="ft-chimney"></rect>
+                        <circle v-for="n in derived.sawmillLevel" :key="'lp'+n" :cx="20 + (n-1)*10" cy="100" r="3" class="ft-level-pip"></circle>
+                      </svg>
+                      <div class="ft-smoke-wrap" v-if="derived.sawmillLevel > 2">
+                        <i v-for="n in 3" :key="n" class="ft-smoke" :class="'ft-smoke-' + n"></i>
+                      </div>
+                    </div>
+
+                    <div class="ft-machine ft-machine-workshop" v-if="derived.workshopBuilt" :class="'ft-lvl-' + derived.workshopLevel" :style="anchorStyle('workshop')" aria-hidden="true">
+                      <svg viewBox="0 0 120 120">
+                        <rect x="8" y="46" width="104" height="62" rx="12" class="ft-body"></rect>
+                        <rect x="40" y="70" width="40" height="24" rx="4" class="ft-slot"></rect>
+                        <g class="ft-arm-group" :class="{'ft-swing': ftActive.workshop}">
+                          <rect x="56" y="14" width="8" height="34" rx="4" class="ft-arm-post"></rect>
+                          <circle cx="60" cy="14" r="9" class="ft-arm-hand"></circle>
+                        </g>
+                        <circle v-for="n in derived.workshopLevel" :key="'wp'+n" :cx="20 + (n-1)*10" cy="102" r="3" class="ft-level-pip"></circle>
+                      </svg>
+                    </div>
+
+                    <div class="ft-machine ft-machine-packaging" v-if="derived.packagingBuilt" :class="'ft-lvl-' + derived.packagingLevel" :style="anchorStyle('packaging')" aria-hidden="true">
+                      <svg viewBox="0 0 120 120">
+                        <rect x="8" y="54" width="104" height="52" rx="12" class="ft-body"></rect>
+                        <rect x="42" y="58" width="36" height="26" rx="3" class="ft-box"></rect>
+                        <polygon class="ft-flap ft-flap-l" :class="{'ft-flap-open': ftActive.packaging}" points="42,58 60,58 42,40"></polygon>
+                        <polygon class="ft-flap ft-flap-r" :class="{'ft-flap-open': ftActive.packaging}" points="78,58 60,58 78,40"></polygon>
+                        <circle v-for="n in derived.packagingLevel" :key="'pp'+n" :cx="20 + (n-1)*10" cy="100" r="3" class="ft-level-pip"></circle>
+                      </svg>
+                    </div>
+
+                    <div class="ft-ship" :style="anchorStyle('ship')" aria-hidden="true">
+                      <svg viewBox="0 0 100 80">
+                        <rect x="8" y="30" width="70" height="40" rx="8" class="ft-truck-body"></rect>
+                        <rect x="78" y="42" width="16" height="24" rx="4" class="ft-truck-cab"></rect>
+                        <circle cx="26" cy="72" r="7" class="ft-wheel"></circle>
+                        <circle cx="66" cy="72" r="7" class="ft-wheel"></circle>
+                        <circle cx="86" cy="72" r="7" class="ft-wheel"></circle>
+                      </svg>
+                    </div>
+
+                    <div class="ft-worker" v-for="n in derived.workersHired" :key="'worker'+n"
+                         :class="['ft-worker-' + n, {'ft-worker-walk': !reducedMotion}]" aria-hidden="true">
+                      <svg viewBox="0 0 30 46">
+                        <circle cx="15" cy="8" r="7" class="ft-worker-head"></circle>
+                        <rect x="7" y="16" width="16" height="18" rx="6" class="ft-worker-body"></rect>
+                        <rect class="ft-worker-leg ft-worker-leg-a" x="8" y="33" width="6" height="12" rx="3"></rect>
+                        <rect class="ft-worker-leg ft-worker-leg-b" x="16" y="33" width="6" height="12" rx="3"></rect>
+                      </svg>
+                    </div>
+
+                    <div class="ft-resource" v-for="item in items" :key="item.id"
+                         :class="'ft-resource-' + item.stageKind"
+                         :style="resourceStyle(item)" aria-hidden="true">
+                      <svg viewBox="0 0 26 26">
+                        <rect x="3" y="3" width="20" height="20" rx="5" class="ft-resource-shape"></rect>
+                      </svg>
+                    </div>
+
+                    <div class="ft-coin-particle" v-for="coin in coins" :key="coin.id" :style="coinStyle(coin)" aria-hidden="true">
+                      <svg viewBox="0 0 20 20"><circle cx="10" cy="10" r="9" class="ft-coin-body"></circle></svg>
+                    </div>
+
+                    <button v-for="badge in badges" :key="'badge'+badge.index" type="button"
+                            class="ft-badge" :class="{'ft-badge-ready': badge.affordable, 'ft-badge-saving': !badge.affordable}"
+                            :style="anchorStyle(badge.item.machine)"
+                            :disabled="!badge.affordable"
+                            @click="attemptUpgrade(badge.index)"
+                            :aria-label="badge.affordable ? ('שדרוג זמין: ' + badge.item.name.value) : ('חוסכים למשדרג: ' + badge.item.name.value)">
+                      <svg viewBox="0 0 24 24" class="ft-badge-icon" aria-hidden="true">
+                        <path d="M12 2 L14.5 8.5 L21 9.3 L16 13.8 L17.5 20.3 L12 16.8 L6.5 20.3 L8 13.8 L3 9.3 L9.5 8.5 Z"></path>
+                      </svg>
+                      <span v-if="!badge.affordable" class="ft-badge-cost">{{ badge.item.cost }}</span>
+                    </button>
+
+                  </div>
+                </div>
+              </div>
+
+              <div class="ft-zoom">
+                <button type="button" class="ft-round-btn ft-zoom-btn" @click="zoomBy(-0.2)" aria-label="התרחק">－</button>
+                <button type="button" class="ft-round-btn ft-zoom-btn" @click="zoomBy(0.2)" aria-label="התקרב">＋</button>
+              </div>
+
+              <div class="ft-score-row"><span class="ft-score">{{ score }}</span></div>
+              <progress-bar :title="'שלב נוכחי'" :progress="progress" :theme="theme"></progress-bar>
+
+              <div class="ft-sr-live" aria-live="polite">{{ liveAnnouncement }}</div>
+
+              <div v-if="pendingUpgrade" class="ft-modal-scrim" @click.self="resolveUpgradeChoice(false)">
+                <section class="ft-modal" role="dialog" aria-modal="true" :aria-label="pendingUpgrade.name.value">
+                  <div class="ft-modal-icon">
+                    <svg viewBox="0 0 24 24"><path d="M12 2 L14.5 8.5 L21 9.3 L16 13.8 L17.5 20.3 L12 16.8 L6.5 20.3 L8 13.8 L3 9.3 L9.5 8.5 Z"></path></svg>
+                  </div>
+                  <h2 class="ft-modal-title">{{ pendingUpgrade.name.value }}?</h2>
+                  <p class="ft-modal-detail">{{ pendingUpgrade.detail && pendingUpgrade.detail.value }}</p>
+                  <div class="ft-modal-cost">
+                    <svg viewBox="0 0 24 24" class="ft-coin-icon-sm"><circle cx="12" cy="12" r="10" class="ft-coin-body"></circle></svg>
+                    <span>{{ pendingUpgrade.cost }}</span>
+                  </div>
+                  <div class="ft-modal-actions">
+                    <button type="button" class="ft-modal-btn ft-modal-cancel" @click="resolveUpgradeChoice(false)">ביטול</button>
+                    <button ref="confirmBtn" type="button" class="ft-modal-btn ft-modal-confirm" @click="resolveUpgradeChoice(true)">שדרג</button>
+                  </div>
+                </section>
+              </div>
+            </div>`,
+
+            data: function () {
+                return {
+                    ftTheme: resolveFactoryTheme(),
+                    weights: [],
+                    purchasedMap: {},
+                    money: 0,
+                    moneyPop: false,
+                    items: [],
+                    coins: [],
+                    ftActive: {sawmill: false, workshop: false, packaging: false},
+                    pendingUpgrade: null,
+                    liveAnnouncement: '',
+                    reducedMotion: false,
+                    zoom: 1,
+                    pan: {x: 0, y: 0},
+                    dragging: false,
+                    dragStart: null,
+                };
+            },
+
+            computed: {
+                list: function () {
+                    return getDataList(this.currentApp.listName);
+                },
+                derived: function () {
+                    const purchased = Object.keys(this.purchasedMap).filter(key => this.purchasedMap[key]).map(Number);
+                    return deriveFactoryState(this.list, purchased);
+                },
+                badges: function () {
+                    const result = [];
+                    for (let index = 0; index < this.weights.length; index += 1) {
+                        if (this.weights[index] > 0 && !this.purchasedMap[index]) {
+                            const item = this.list[index];
+                            if (item) result.push({index: index, item: item, affordable: this.money >= item.cost});
+                        }
+                    }
+                    return result;
+                },
+                learningPercent: function () {
+                    if (!this.progress || !this.progress.total) return 0;
+                    return Math.max(0, Math.min(100, Math.round((this.progress.progress / this.progress.total) * 100)));
+                },
+                displayMoney: function () {
+                    return Math.floor(this.money);
+                },
+                cameraStyle: function () {
+                    return {transform: `translate(${this.pan.x}px, ${this.pan.y}px) scale(${this.zoom})`};
+                },
+            },
+
+            methods: {
+                storageKey: function (suffix) {
+                    return `${this.currentAppId}_ft_${suffix}`;
+                },
+                anchorStyle: function (machineKey) {
+                    const anchor = FT_ANCHORS[machineKey] || {x: 50, y: 50};
+                    return {left: anchor.x + '%', top: anchor.y + '%'};
+                },
+                beltStyle: function (key) {
+                    const from = key === 'conveyor1' ? FT_ANCHORS.sawmill.x : FT_ANCHORS.workshop.x;
+                    const to = key === 'conveyor1' ? FT_ANCHORS.workshop.x : FT_ANCHORS.packaging.x;
+                    return {left: to + '%', width: (from - to) + '%', top: FT_ANCHORS[key].y + '%'};
+                },
+                pathLineStyle: function () {
+                    return {left: FT_ANCHORS.ship.x + '%', width: (FT_ANCHORS.sawmill.x - FT_ANCHORS.ship.x) + '%'};
+                },
+                bladeTooth: function (n) {
+                    const angle = (n / 8) * Math.PI * 2;
+                    const cx = 76, cy = 54, rInner = 20, rOuter = 27;
+                    const x1 = cx + Math.cos(angle) * rInner, y1 = cy + Math.sin(angle) * rInner;
+                    const x2 = cx + Math.cos(angle + 0.18) * rOuter, y2 = cy + Math.sin(angle + 0.18) * rOuter;
+                    const x3 = cx + Math.cos(angle - 0.18) * rOuter, y3 = cy + Math.sin(angle - 0.18) * rOuter;
+                    return `${x1},${y1} ${x2},${y2} ${x3},${y3}`;
+                },
+                resourceStyle: function (item) {
+                    return {left: item.x + '%', top: item.y + '%', opacity: item.visible ? 1 : 0};
+                },
+                coinStyle: function (coin) {
+                    return {left: coin.x + '%', top: coin.y + '%', opacity: coin.opacity};
+                },
+
+                loadMoney: function () {
+                    this.money = Number(getLocalStorage(this.storageKey('money'), 0)) || 0;
+                },
+                saveMoney: function () {
+                    setLocalStorage(this.storageKey('money'), this.money);
+                },
+                loadPurchased: function () {
+                    const stored = getLocalStorage(this.storageKey('purchased'), []);
+                    const map = {};
+                    (stored || []).forEach(index => { map[index] = true; });
+                    this.purchasedMap = map;
+                },
+                savePurchased: function () {
+                    setLocalStorage(this.storageKey('purchased'), Object.keys(this.purchasedMap).filter(key => this.purchasedMap[key]).map(Number));
+                },
+
+                later: function (callback, delay) {
+                    const token = this._runTokenFt;
+                    const timer = setTimeout(() => {
+                        this._timersFt.delete(timer);
+                        if (!this._destroyedFt && token === this._runTokenFt && this.isCurrentRoute()) callback();
+                    }, this.reducedMotion ? Math.min(delay, 140) : delay);
+                    this._timersFt.add(timer);
+                    return timer;
+                },
+                isCurrentRoute: function () {
+                    return this.$route && this.$route.params.currentAppId === this.currentAppId
+                        && this.$route.path.indexOf('/play/factory_tycoon/') === 0;
+                },
+                clearTimersFt: function () {
+                    this._timersFt.forEach(timer => clearTimeout(timer));
+                    this._timersFt.clear();
+                },
+
+                create: function () {
+                    this.ftTheme = resolveFactoryTheme();
+                    this.loadMoney();
+                    this.loadPurchased();
+                    this.weights = getWeightsForKey(this.currentAppId, getSetItems(this.currentApp), this.list);
+                    this.items = [];
+                    this.coins = [];
+                    this._runTokenFt = (this._runTokenFt || 0) + 1;
+                    // create() runs before mount (BaseGameComponent.created()), but the
+                    // timer/RAF registries are only set up in mounted() — defer the loop
+                    // kick-off past that point, same as games/water-pipeline.js.
+                    this.$nextTick(() => {
+                        if (this._destroyedFt || !this.isCurrentRoute()) return;
+                        this.startSawmillLoop();
+                    });
+                },
+
+                startSawmillLoop: function () {
+                    // Self-invalidating timeout chain (not setInterval): each cycle reads
+                    // the current sawmill level, so an upgrade speeds up the very next
+                    // tick without ever creating a second parallel loop.
+                    this.scheduleSawmillTick();
+                },
+                scheduleSawmillTick: function () {
+                    const token = this._runTokenFt;
+                    const delay = FT_SAWMILL_INTERVAL(this.derived.sawmillLevel);
+                    const timer = setTimeout(() => {
+                        this._timersFt.delete(timer);
+                        if (this._destroyedFt || token !== this._runTokenFt || !this.isCurrentRoute()) return;
+                        this.spawnResource();
+                        this.scheduleSawmillTick();
+                    }, delay);
+                    this._timersFt.add(timer);
+                },
+
+                pulse: function (key) {
+                    this.$set(this.ftActive, key, true);
+                    this.later(() => { this.$set(this.ftActive, key, false); }, FT_PROCESS_PAUSE - 40);
+                },
+
+                speedFactor: function () {
+                    return this.reducedMotion ? 0.2 : Math.max(0.55, 1 - this.derived.workersHired * 0.07);
+                },
+
+                spawnResource: function () {
+                    if (this.items.length >= FT_MAX_ITEMS) return;
+                    const item = {
+                        id: 'r' + (this._itemSeqFt = (this._itemSeqFt || 0) + 1),
+                        x: FT_ANCHORS.sawmill.x,
+                        y: FT_ANCHORS.sawmill.y,
+                        visible: true,
+                        stageKind: 'raw',
+                        value: FT_BASE_VALUE,
+                    };
+                    this.items.push(item);
+                    this.pulse('sawmill');
+                    this.runLeg(item, this.derived.workshopBuilt ? 'workshop' : (this.derived.packagingBuilt ? 'packaging' : 'ship'));
+                },
+
+                raf: function (callback) {
+                    const handle = requestAnimationFrame(() => {
+                        this._rafSetFt.delete(handle);
+                        callback();
+                    });
+                    this._rafSetFt.add(handle);
+                    return handle;
+                },
+
+                runLeg: function (item, targetKey) {
+                    const from = FT_ANCHORS[item._at || 'sawmill'] || FT_ANCHORS.sawmill;
+                    const to = FT_ANCHORS[targetKey];
+                    const duration = FT_LEG_DURATION * this.speedFactor();
+                    const start = Date.now();
+                    const token = this._runTokenFt;
+                    const step = () => {
+                        if (this._destroyedFt || token !== this._runTokenFt || !this.isCurrentRoute()) return;
+                        const raw = Math.min(1, (Date.now() - start) / duration);
+                        const eased = raw < 0.5 ? 2 * raw * raw : 1 - Math.pow(-2 * raw + 2, 2) / 2;
+                        item.x = from.x + (to.x - from.x) * eased;
+                        item.y = from.y + (to.y - from.y) * eased;
+                        if (raw < 1) {
+                            this.raf(step);
+                        } else {
+                            item._at = targetKey;
+                            this.arriveAtStation(item, targetKey);
+                        }
+                    };
+                    this.raf(step);
+                },
+
+                arriveAtStation: function (item, key) {
+                    if (key === 'workshop') {
+                        item.stageKind = 'processed-a';
+                        item.value += FT_WORKSHOP_BONUS(this.derived.workshopLevel);
+                        this.pulse('workshop');
+                        this.later(() => this.runLeg(item, this.derived.packagingBuilt ? 'packaging' : 'ship'), FT_PROCESS_PAUSE);
+                    } else if (key === 'packaging') {
+                        item.stageKind = 'processed-b';
+                        item.value += FT_PACKAGING_BONUS(this.derived.packagingLevel);
+                        this.pulse('packaging');
+                        this.later(() => this.runLeg(item, 'ship'), FT_PROCESS_PAUSE);
+                    } else {
+                        this.shipItem(item);
+                    }
+                },
+
+                shipItem: function (item) {
+                    item.visible = false;
+                    this.items = this.items.filter(candidate => candidate.id !== item.id);
+                    this.money += item.value;
+                    this.moneyPop = true;
+                    this.later(() => { this.moneyPop = false; }, 260);
+                    this.saveMoney();
+                    this.spawnCoin();
+                },
+
+                spawnCoin: function () {
+                    const coin = {id: 'c' + (this._coinSeqFt = (this._coinSeqFt || 0) + 1), x: FT_ANCHORS.ship.x, y: FT_ANCHORS.ship.y, opacity: 1};
+                    this.coins.push(coin);
+                    const duration = this.reducedMotion ? 160 : 620;
+                    const start = Date.now();
+                    const token = this._runTokenFt;
+                    const step = () => {
+                        if (this._destroyedFt || token !== this._runTokenFt) return;
+                        const raw = Math.min(1, (Date.now() - start) / duration);
+                        coin.x = FT_ANCHORS.ship.x + (2 - FT_ANCHORS.ship.x) * raw;
+                        coin.y = FT_ANCHORS.ship.y - raw * 40;
+                        coin.opacity = 1 - raw;
+                        if (raw < 1) {
+                            this.raf(step);
+                        } else {
+                            this.coins = this.coins.filter(candidate => candidate.id !== coin.id);
+                        }
+                    };
+                    this.raf(step);
+                },
+
+                confirmUpgrade: function (item) {
+                    // Sole gate for every upgrade in the game. Swap this method's body
+                    // for a real question/quiz gate later; every caller stays the same.
+                    return new Promise(resolve => {
+                        this.pendingUpgrade = item;
+                        this._resolveUpgradeFt = resolve;
+                        this.$nextTick(() => {
+                            if (this.$refs.confirmBtn) this.$refs.confirmBtn.focus();
+                        });
+                    });
+                },
+                resolveUpgradeChoice: function (accepted) {
+                    if (!this.pendingUpgrade) return;
+                    const resolve = this._resolveUpgradeFt;
+                    this.pendingUpgrade = null;
+                    this._resolveUpgradeFt = null;
+                    if (resolve) resolve(accepted);
+                },
+
+                attemptUpgrade: async function (index) {
+                    if (this._upgradeBusyFt || this.pendingUpgrade) return;
+                    const item = this.list[index];
+                    if (!item || this.weights[index] <= 0 || this.purchasedMap[index]) return;
+                    if (this.money < item.cost) return;
+                    this._upgradeBusyFt = true;
+                    let accepted = false;
+                    try {
+                        accepted = await this.confirmUpgrade(item);
+                    } finally {
+                        this._upgradeBusyFt = false;
+                    }
+                    if (this._destroyedFt || !this.isCurrentRoute() || !accepted) return;
+
+                    this.money -= item.cost;
+                    this.saveMoney();
+                    this.$set(this.purchasedMap, index, true);
+                    this.savePurchased();
+                    this.liveAnnouncement = `שודרג: ${item.name.value}`;
+                    try { successSound.play(); } catch (e) {}
+
+                    this.weights = updateWeightForKey(this.currentAppId, index, -15);
+                    this.score += 1;
+                    if (this.reloadProgress()) {
+                        this.saveScore();
+                    }
+                },
+
+                zoomBy: function (delta) {
+                    this.zoom = Math.max(0.75, Math.min(1.6, this.zoom + delta));
+                },
+                startPan: function (event) {
+                    this.dragging = true;
+                    this.dragStart = {x: event.clientX - this.pan.x, y: event.clientY - this.pan.y};
+                },
+                movePan: function (event) {
+                    if (!this.dragging || !this.dragStart) return;
+                    const maxPan = 140 * this.zoom;
+                    this.pan = {
+                        x: Math.max(-maxPan, Math.min(maxPan, event.clientX - this.dragStart.x)),
+                        y: Math.max(-60, Math.min(60, event.clientY - this.dragStart.y)),
+                    };
+                },
+                endPan: function () {
+                    this.dragging = false;
+                    this.dragStart = null;
+                },
+
+                toggleFullscreen: function () {
+                    const root = this.$refs.root;
+                    if (!root) return;
+                    if (document.fullscreenElement || document.webkitFullscreenElement) {
+                        const exit = document.exitFullscreen || document.webkitExitFullscreen;
+                        if (exit) exit.call(document);
+                    } else {
+                        const request = root.requestFullscreen || root.webkitRequestFullscreen;
+                        if (request) {
+                            const result = request.call(root);
+                            if (result && result.catch) result.catch(() => {});
+                        }
+                    }
+                },
+                exitGame: function () {
+                    if (typeof parseAdventureId === 'function') {
+                        const parsed = parseAdventureId(this.currentAppId);
+                        if (parsed) {
+                            this.$router.push('/adventure/world/' + parsed.world.id);
+                            return;
+                        }
+                    }
+                    this.$router.push('/app/' + this.currentAppId);
+                },
+            },
+
+            mounted: function () {
+                this._destroyedFt = false;
+                this._timersFt = new Set();
+                this._rafSetFt = new Set();
+                this._runTokenFt = (this._runTokenFt || 0) + 1;
+                this._mediaFt = window.matchMedia ? window.matchMedia('(prefers-reduced-motion: reduce)') : null;
+                this.reducedMotion = !!(this._mediaFt && this._mediaFt.matches);
+            },
+
+            beforeDestroy: function () {
+                this._destroyedFt = true;
+                this._runTokenFt = (this._runTokenFt || 0) + 1;
+                this.clearTimersFt();
+                if (this._rafSetFt) {
+                    this._rafSetFt.forEach(handle => cancelAnimationFrame(handle));
+                    this._rafSetFt.clear();
+                }
+                if (this.pendingUpgrade) this.resolveUpgradeChoice(false);
+                if (document.fullscreenElement === this.$refs.root && document.exitFullscreen) {
+                    document.exitFullscreen().catch(() => {});
+                }
+            },
+        }));
+    }
+
+    global.FT_DEFAULT_MACHINES = FT_DEFAULT_MACHINES;
+    global.FT_ANCHORS = FT_ANCHORS;
+    global.validateFactoryUpgrades = validateFactoryUpgrades;
+    global.deriveFactoryState = deriveFactoryState;
+    global.resolveFactoryTheme = resolveFactoryTheme;
+    global.createFactoryTycoonComponent = createFactoryTycoonComponent;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
     <link rel="stylesheet" href="./adventure.css">
     <link rel="stylesheet" href="./games/water-pipeline.css">
+    <link rel="stylesheet" href="./games/factory-tycoon.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 
     <style>
@@ -1362,7 +1363,8 @@
 
 <!-- Large standalone game modules expose guarded component factories. -->
 <script src="./games/water-pipeline.js"></script>
-<script src="./tester.js?v=18"></script>
+<script src="./games/factory-tycoon.js"></script>
+<script src="./tester.js?v=19"></script>
 
 <script src="https://unpkg.com/tesseract.js@v2.1.0/dist/tesseract.min.js"></script>
 </body>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'my-app-cache-v37';
+const CACHE_NAME = 'my-app-cache-v38';
 const CORE_ASSETS = [
   '/',
   '/index.html',
@@ -11,9 +11,11 @@ const CORE_ASSETS = [
   '/adventure.css',
   '/games/water-pipeline.js',
   '/games/water-pipeline.css',
+  '/games/factory-tycoon.js',
+  '/games/factory-tycoon.css',
   '/themes.js',
   '/storage.js',
-  '/tester.js?v=18',
+  '/tester.js?v=19',
   '/sounds/success.mp3',
   '/sounds/failure.mp3',
   '/assets/svg/tall.svg',

--- a/tester.js
+++ b/tester.js
@@ -9857,6 +9857,11 @@ if (typeof createWaterPipelineComponent === 'function') {
     WaterPipelineComponent = createWaterPipelineComponent(BaseGameComponent);
 }
 
+var FactoryTycoonComponent = null;
+if (typeof createFactoryTycoonComponent === 'function') {
+    FactoryTycoonComponent = createFactoryTycoonComponent(BaseGameComponent);
+}
+
 const routes = [
     {path: '/', component: MenuComponent,},
     {path: '/user', component: UserComponent},
@@ -9884,6 +9889,10 @@ const routes = [
 
 if (WaterPipelineComponent) {
     routes.push({path: '/play/water_pipeline/:currentAppId', component: WaterPipelineComponent, props: true});
+}
+
+if (FactoryTycoonComponent) {
+    routes.push({path: '/play/factory_tycoon/:currentAppId', component: FactoryTycoonComponent, props: true});
 }
 
 // Adventure mode routes (adventure.js) — appended only when the module is loaded

--- a/tests/factory_tycoon_test.js
+++ b/tests/factory_tycoon_test.js
@@ -1,0 +1,239 @@
+// Focused tests for the Factory Tycoon game. The production module exposes
+// pure configuration/state helpers and a Vue component factory, so its
+// contracts can be exercised without a browser renderer.
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.join(__dirname, '..');
+const GAME_SOURCE = fs.readFileSync(path.join(ROOT, 'games/factory-tycoon.js'), 'utf8');
+
+let passed = 0;
+let failed = 0;
+function check(name, condition, extra) {
+    if (condition) {
+        passed += 1;
+        console.log('  PASS', name);
+    } else {
+        failed += 1;
+        console.log('  FAIL', name, extra === undefined ? '' : '| ' + extra);
+    }
+}
+
+function makeThemeOptions() {
+    const palette = (primary, secondary, tertiary, accent, background, text) => ({
+        colors: {primary, secondary, tertiary, accent, background, text},
+    });
+    return {
+        base: palette('#006064', '#78909c', '#B0E0E6', '#C0C0C0', '#F5F5F5', '#000000'),
+        soldiers: palette('#4B5320', '#C0C0C0', '#BDB76B', '#FFD700', '#F0F0E0', '#000000'),
+        unicorn: palette('#FF69B4', '#BA55D3', '#FFB6C1', '#FFD700', '#FFF0F5', '#4B0082'),
+        space: palette('#1E90FF', '#000080', '#87CEEB', '#FFD700', '#000020', '#FFFFFF'),
+        dark: palette('#121212', '#1E1E1E', '#2F4F4F', '#BB86FC', '#1C1C1C', '#E0E0E0'),
+        code: palette('#00FF41', '#008F11', '#0D2818', '#39FF14', '#050A05', '#00FF41'),
+    };
+}
+
+function makeGameContext() {
+    let selectedTheme = 'base';
+    const context = {
+        console,
+        setTimeout,
+        clearTimeout,
+        requestAnimationFrame: () => 0,
+        cancelAnimationFrame: () => {},
+        themeOptions: makeThemeOptions(),
+        getLocalStorage: key => key === 'theme' ? selectedTheme : null,
+        Vue: {
+            extend: definition => definition,
+            component: (name, definition) => definition,
+        },
+    };
+    context.window = context;
+    context.globalThis = context;
+    context.setThemeForTest = key => { selectedTheme = key; };
+    vm.createContext(context);
+    vm.runInContext(GAME_SOURCE, context, {filename: 'games/factory-tycoon.js'});
+    return context;
+}
+
+console.log('--- 1. tech tree configuration ---');
+const ctx = makeGameContext();
+const FACTORY_UPGRADES = vm.runInContext(
+    fs.readFileSync(path.join(ROOT, 'data.js'), 'utf8') + ';DATA.FACTORY_UPGRADES',
+    (() => { const c = {}; vm.createContext(c); return c; })()
+);
+check('DATA.FACTORY_UPGRADES has content', Array.isArray(FACTORY_UPGRADES) && FACTORY_UPGRADES.length > 0, FACTORY_UPGRADES && FACTORY_UPGRADES.length);
+check('tech tree passes validation', ctx.validateFactoryUpgrades(FACTORY_UPGRADES).length === 0, JSON.stringify(ctx.validateFactoryUpgrades(FACTORY_UPGRADES)));
+check('tech tree length divides evenly into batches of 4 (setItems)', FACTORY_UPGRADES.length % 4 === 0, FACTORY_UPGRADES.length);
+check('validation rejects an unknown machine key', ctx.validateFactoryUpgrades([
+    {name: {type: 'text', value: 'x'}, machine: 'not-a-machine', level: 1, kind: 'upgrade', cost: 10},
+]).length === 1);
+check('validation rejects a non-positive cost', ctx.validateFactoryUpgrades([
+    {name: {type: 'text', value: 'x'}, machine: 'sawmill', level: 1, kind: 'upgrade', cost: 0},
+]).length === 1);
+
+console.log('--- 2. derived factory state is independent of engine weight resets ---');
+check('with nothing purchased, only the starting sawmill (level 1) exists',
+    JSON.stringify(ctx.deriveFactoryState(FACTORY_UPGRADES, []).machines) ===
+    JSON.stringify(ctx.FT_DEFAULT_MACHINES || {sawmill: 1, workshop: 0, packaging: 0, conveyor1: 0, conveyor2: 0, worker1: 0, worker2: 0, worker3: 0, storage: 0, sign: 0}));
+const partial = ctx.deriveFactoryState(FACTORY_UPGRADES, [0, 2, 3]);
+check('purchasing indices 0,2,3 upgrades sawmill, hires worker1, builds workshop',
+    partial.machines.sawmill === 2 && partial.machines.worker1 === 1 && partial.workshopBuilt === true, JSON.stringify(partial));
+check('workersHired counts only hired worker slots', partial.workersHired === 1);
+const everything = ctx.deriveFactoryState(FACTORY_UPGRADES, FACTORY_UPGRADES.map((_, index) => index));
+check('purchasing every item reaches the maxed-out factory', everything.sawmillLevel === 4 && everything.workersHired === 3 && everything.packagingBuilt === true);
+check('a later weight reset (site-wide practice-mode loop) cannot be represented as "unbuilt" because state is derived only from purchases, not from weights',
+    ctx.deriveFactoryState(FACTORY_UPGRADES, [0]).machines.sawmill === 2);
+
+console.log('--- 3. all six themes resolve through one adapter ---');
+['base', 'soldiers', 'unicorn', 'space', 'dark', 'code'].forEach(key => {
+    ctx.setThemeForTest(key);
+    const resolved = ctx.resolveFactoryTheme();
+    check(`${key} theme resolves`, resolved.key === key);
+    check(`${key} exposes semantic tokens and a scene name`,
+        !!resolved.css['--ft-primary'] && !!resolved.css['--ft-panel'] && !!resolved.motif.sceneName, JSON.stringify(resolved));
+});
+ctx.setThemeForTest('unknown-theme');
+check('unknown theme safely falls back to base', ctx.resolveFactoryTheme().key === 'base');
+
+console.log('--- 4. confirmUpgrade() is the sole gate for the learning transaction ---');
+function makeUpgradeInstance(definition, overrides) {
+    return Object.assign(definition.data(), {
+        currentAppId: 'ft-test',
+        currentApp: {listName: 'FACTORY_UPGRADES'},
+        list: [{name: {value: 'Upgrade A'}, detail: {value: 'd'}, machine: 'sawmill', level: 2, kind: 'upgrade', cost: 50}],
+        weights: [5],
+        purchasedMap: {},
+        money: 100,
+        score: 0,
+        $set: (target, key, value) => { target[key] = value; },
+        $nextTick: callback => callback(),
+        saveMoney: function () {},
+        savePurchased: function () {},
+        saveScore: function () {},
+        isCurrentRoute: () => true,
+        reloadProgress: () => true,
+    }, overrides);
+}
+
+const definition = ctx.createFactoryTycoonComponent({});
+const methods = definition.methods;
+let reports = [];
+ctx.updateWeightForKey = (key, index, change) => { reports.push({key, index, change}); return [0]; };
+ctx.successSound = {play() {}};
+
+(async function runLifecycleTests() {
+    reports.length = 0;
+    const confirmed = makeUpgradeInstance(definition, {confirmUpgrade: () => Promise.resolve(true)});
+    await methods.attemptUpgrade.call(confirmed, 0);
+    check('confirmed upgrade reports exactly one weight update of -15 (fully masters that tech-tree item)',
+        reports.length === 1 && reports[0].change === -15, JSON.stringify(reports));
+    check('confirmed upgrade deducts the cost from money', confirmed.money === 50, confirmed.money);
+    check('confirmed upgrade marks the item permanently purchased', confirmed.purchasedMap[0] === true);
+    check('confirmed upgrade increments score once', confirmed.score === 1);
+
+    reports.length = 0;
+    const cancelled = makeUpgradeInstance(definition, {confirmUpgrade: () => Promise.resolve(false)});
+    await methods.attemptUpgrade.call(cancelled, 0);
+    check('cancelling reports no weight update', reports.length === 0);
+    check('cancelling leaves money untouched', cancelled.money === 100);
+    check('cancelling does not mark the item purchased', !cancelled.purchasedMap[0]);
+
+    let confirmOpenCount = 0;
+    const busy = makeUpgradeInstance(definition, {
+        confirmUpgrade: function () { confirmOpenCount += 1; return new Promise(resolve => { busy._resolveTest = resolve; }); },
+    });
+    const first = methods.attemptUpgrade.call(busy, 0);
+    const second = methods.attemptUpgrade.call(busy, 0);
+    busy._resolveTest(true);
+    await first; await second;
+    check('a second concurrent attempt while a dialog is open does not open a second dialog', confirmOpenCount === 1);
+
+    reports.length = 0;
+    const destroyed = makeUpgradeInstance(definition, {
+        confirmUpgrade: function () { destroyed._destroyedFt = true; return Promise.resolve(true); },
+    });
+    await methods.attemptUpgrade.call(destroyed, 0);
+    check('a component destroyed while the dialog was open applies no state after resolution',
+        reports.length === 0 && destroyed.money === 100);
+
+    reports.length = 0;
+    const locked = makeUpgradeInstance(definition, {weights: [-1]});
+    await methods.attemptUpgrade.call(locked, 0);
+    check('a locked (not-yet-open) item cannot be upgraded', reports.length === 0);
+
+    reports.length = 0;
+    const alreadyDone = makeUpgradeInstance(definition, {weights: [0], purchasedMap: {0: true}});
+    await methods.attemptUpgrade.call(alreadyDone, 0);
+    check('an already-purchased item cannot be purchased again', reports.length === 0);
+
+    let dialogOpened = false;
+    const poor = makeUpgradeInstance(definition, {
+        money: 10,
+        confirmUpgrade: function () { dialogOpened = true; return Promise.resolve(true); },
+    });
+    await methods.attemptUpgrade.call(poor, 0);
+    check('insufficient money never opens the confirmation dialog', !dialogOpened);
+
+    let saveScoreCalls = 0;
+    const stageComplete = makeUpgradeInstance(definition, {
+        confirmUpgrade: () => Promise.resolve(true),
+        saveScore: function () { saveScoreCalls += 1; },
+        reloadProgress: () => false,
+    });
+    await methods.attemptUpgrade.call(stageComplete, 0);
+    check('reloadProgress() === false (engine navigated away) skips saveScore, following MCQComponent', saveScoreCalls === 0);
+
+    saveScoreCalls = 0;
+    const stageContinues = makeUpgradeInstance(definition, {
+        confirmUpgrade: () => Promise.resolve(true),
+        saveScore: function () { saveScoreCalls += 1; },
+        reloadProgress: () => true,
+    });
+    await methods.attemptUpgrade.call(stageContinues, 0);
+    check('reloadProgress() === true saves score and continues', saveScoreCalls === 1);
+
+    console.log('--- 5. legacy registration ---');
+    function makeStorage() {
+        const map = new Map();
+        return {
+            getItem: key => map.has(key) ? map.get(key) : null,
+            setItem: (key, value) => map.set(key, String(value)),
+            _map: map,
+        };
+    }
+    const integration = {
+        console,
+        localStorage: makeStorage(),
+        sessionStorage: makeStorage(),
+        navigator: {},
+        Audio: class { play() {} },
+        he: {decode: value => value},
+    };
+    integration.window = integration;
+    integration.globalThis = integration;
+    integration.sessionStorage.setItem('username', 'factory-test');
+    vm.createContext(integration);
+    function load(file, suffix = '') {
+        vm.runInContext(fs.readFileSync(path.join(ROOT, file), 'utf8') + suffix, integration, {filename: file});
+    }
+    load('data.js', ';globalThis.DATA=DATA;');
+    load('apps.js', ';globalThis.apps=apps;');
+    load('worlds.js');
+    load('storage.js');
+    const tester = fs.readFileSync(path.join(ROOT, 'tester.js'), 'utf8');
+    const cut = tester.indexOf('var ProgressBarComponent');
+    vm.runInContext(tester.slice(0, cut), integration, {filename: 'tester.js(core)'});
+    const legacyFactory = vm.runInContext(
+        `(function find(node){ if(node.type==='app' && node.appType==='factory_tycoon') return node; for(const child of (node.items||[])){const found=find(child);if(found)return found;} return null;})(apps)`,
+        integration
+    );
+    check('legacy menu registers a complete factory_tycoon app',
+        legacyFactory && legacyFactory.listName === 'FACTORY_UPGRADES' && legacyFactory.setItems === 4, JSON.stringify(legacyFactory));
+    check('the registered list resolves through the shared data API and passes validation',
+        ctx.validateFactoryUpgrades(integration.DATA.FACTORY_UPGRADES).length === 0);
+
+    console.log(`\n${passed} passed, ${failed} failed`);
+    if (failed) process.exit(1);
+})();


### PR DESCRIPTION
New appType `factory_tycoon` (games/factory-tycoon.js/.css) registered under
a new "מפעל" menu entry. The player starts with one sawmill; resources
animate along conveyor belts through an optional workshop and packaging
station to a shipping truck, earning coins that gate a 16-step tech tree
(machines, conveyors, workers, storage, a sign) across all six site themes.

Every upgrade routes through one isolated confirmUpgrade() dialog
(Cancel/Upgrade) instead of any quiz/question logic, per the brief — the
factory's built state is derived from a permanent purchased-record so it
survives the learning engine's spaced-repetition weight resets, while score/
progress/new-item unlocking still flow through the existing engine
(updateWeightForKey, reloadProgress) exactly like every other game here.

Adds tests/factory_tycoon_test.js (config validation, derived-state purity,
all-theme resolution, confirm/cancel lifecycle, legacy registration) and
wires the new files into index.html and service-worker.js (CACHE_NAME v38).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XzdarUpoKrto4QZgpD9bEb