### PR TITLE
Add upgrade badges and Chapter 4 question gate to Factory Tycoon

### DIFF
--- a/apps.js
+++ b/apps.js
@@ -364,7 +364,7 @@ apps =  {
       name: 'מפעל',
       type: 'menu',
       items: [
-        {icon: 'precision_manufacturing', name:'מפעל הצעצועים', type: 'app', appType: 'factory_tycoon', listName: 'FACTORY_UPGRADES', questionIndex: 'name', resultIndex: 'name', setItems: 4, quizListName: 'ENGLISH_CHAPTER4_ALL', quizQuestionIndex: 'english_name', quizResultIndex: 'hebrew', title: 'ענו נכון על שאלות פרק 4 כדי לשדרג את המפעל'},
+        {icon: 'precision_manufacturing', name:'מפעל הצעצועים', type: 'app', appType: 'factory_tycoon', listName: 'FACTORY_UPGRADES', questionIndex: 'name', resultIndex: 'name', setItems: 4, quizListName: 'ENGLISH_CHAPTER4_ALL', quizQuestionIndex: 'english_name', quizResultIndex: 'hebrew', quizSetItems: 10, title: 'ענו נכון על שאלות פרק 4 כדי לשדרג את המפעל'},
       ]
     },
   ]

--- a/apps.js
+++ b/apps.js
@@ -364,7 +364,7 @@ apps =  {
       name: 'מפעל',
       type: 'menu',
       items: [
-        {icon: 'precision_manufacturing', name:'מפעל הצעצועים', type: 'app', appType: 'factory_tycoon', listName: 'FACTORY_UPGRADES', questionIndex: 'name', resultIndex: 'name', setItems: 4, title: 'בנו ושדרגו מפעל צעצועים חי'},
+        {icon: 'precision_manufacturing', name:'מפעל הצעצועים', type: 'app', appType: 'factory_tycoon', listName: 'FACTORY_UPGRADES', questionIndex: 'name', resultIndex: 'name', setItems: 4, quizListName: 'ENGLISH_CHAPTER4_ALL', quizQuestionIndex: 'english_name', quizResultIndex: 'hebrew', title: 'ענו נכון על שאלות פרק 4 כדי לשדרג את המפעל'},
       ]
     },
   ]

--- a/games/factory-tycoon.css
+++ b/games/factory-tycoon.css
@@ -56,6 +56,21 @@
 .ft-modal-actions .confirm{color:#3d2800;background:linear-gradient(180deg,#ffdf7e,#f5b02c);box-shadow:0 4px 0 #c07f12}
 .ft-modal-actions .confirm:active{transform:translateY(3px);box-shadow:0 1px 0 #c07f12}
 
+/* educational quiz inside the upgrade modal */
+.ft-quiz-callout{margin:0 0 8px;font-size:13.5px;font-weight:800;opacity:.85}
+.ft-quiz-prompt{display:block;width:100%;border:0;border-radius:14px;padding:12px 10px;margin:0 0 10px;font-size:clamp(19px,5vw,24px);font-weight:900;direction:ltr;background:rgba(125,138,170,.16);color:inherit;cursor:pointer}
+.ft-quiz-prompt:active{transform:scale(.985)}
+.ft-quiz-options{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin:0 0 8px}
+.ft-quiz-options button{border:0;border-radius:13px;padding:12px 8px;font-size:15px;font-weight:800;background:rgba(125,138,170,.2);color:inherit;cursor:pointer;transition:transform .12s ease,background .16s ease}
+.ft-quiz-options button:active:not(:disabled){transform:scale(.96)}
+.ft-quiz-options button:disabled{cursor:default}
+.ft-quiz-options button.correct{background:#2f9e52;color:#fff}
+.ft-quiz-options button.wrong{background:#d64545;color:#fff}
+.ft-quiz-options button:focus-visible{outline:3px solid var(--ft-glow);outline-offset:2px}
+.ft-quiz-feedback{margin:0 0 10px;min-height:18px;font-size:13.5px;font-weight:800;text-align:center}
+.ft-quiz-feedback.ok{color:#2f9e52}
+.ft-quiz-feedback.bad{color:#d64545}
+
 .ft-sr-live{position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap}
 
 /* larger screens: sheet becomes a floating card so the scene stays visible */

--- a/games/factory-tycoon.js
+++ b/games/factory-tycoon.js
@@ -146,10 +146,14 @@
     }
 
     // ---- educational question engine ------------------------------------------
-    // Every upgrade must be earned by answering a vocabulary question. The quiz
-    // list is configurable per app entry (quizListName/quizQuestionIndex/
-    // quizResultIndex in apps.js) and defaults to the Chapter 4 word list.
-    var FT_QUIZ_DEFAULTS = {listName: 'ENGLISH_CHAPTER4_ALL', questionIndex: 'english_name', resultIndex: 'hebrew'};
+    // Every upgrade must be earned by answering a vocabulary question served by
+    // the shared learning engine (generateFromList): weighted selection prefers
+    // weak words, batches unlock via setItems, and every answer is reported with
+    // updateWeightForKey under a dedicated "<appId>_quiz" knowledge key — the
+    // same mechanism as MCQComponent, independent of the factory tech tree. The
+    // quiz list is configurable per app entry (quizListName/quizQuestionIndex/
+    // quizResultIndex/quizSetItems in apps.js) and defaults to Chapter 4 words.
+    var FT_QUIZ_DEFAULTS = {listName: 'ENGLISH_CHAPTER4_ALL', questionIndex: 'english_name', resultIndex: 'hebrew', setItems: 10};
     var FT_QUIZ_DELAYS = {correct: 700, wrong: 1700};
 
     function resolveFactoryQuiz(app) {
@@ -157,43 +161,8 @@
         return {
             listName: app.quizListName || FT_QUIZ_DEFAULTS.listName,
             questionIndex: app.quizQuestionIndex || FT_QUIZ_DEFAULTS.questionIndex,
-            resultIndex: app.quizResultIndex || FT_QUIZ_DEFAULTS.resultIndex
-        };
-    }
-
-    function buildUpgradeQuestion(list, questionIndex, resultIndex, rng) {
-        rng = rng || Math.random;
-        if (!Array.isArray(list) || !list.length) return null;
-        var qi = Math.floor(rng() * list.length);
-        var item = list[qi];
-        if (!item || !item[questionIndex] || !item[resultIndex]) return null;
-        var answer = item[resultIndex].value;
-        if (typeof answer !== 'string' || !answer) return null;
-        var seen = {};
-        seen[answer] = true;
-        var pool = [];
-        list.forEach(function (other, index) {
-            if (index === qi || !other || !other[resultIndex]) return;
-            var value = other[resultIndex].value;
-            if (typeof value !== 'string' || !value || seen[value]) return;
-            seen[value] = true;
-            pool.push(value);
-        });
-        function shuffle(arr) {
-            for (var i = arr.length - 1; i > 0; i--) {
-                var j = Math.floor(rng() * (i + 1));
-                var t = arr[i]; arr[i] = arr[j]; arr[j] = t;
-            }
-            return arr;
-        }
-        if (!pool.length) return null;
-        var options = shuffle([answer].concat(shuffle(pool).slice(0, 3)));
-        var promptField = item[questionIndex];
-        return {
-            prompt: promptField.value,
-            speak: promptField.type === 'text_to_speech' || promptField.type === 'speech',
-            answer: answer,
-            options: options
+            resultIndex: app.quizResultIndex || FT_QUIZ_DEFAULTS.resultIndex,
+            setItems: typeof app.quizSetItems === 'number' ? app.quizSetItems : FT_QUIZ_DEFAULTS.setItems
         };
     }
 
@@ -1394,11 +1363,23 @@
                     this.selectedMachine = null;
                     if (this._sceneApi) this._sceneApi.clearSelection();
                 },
+                quizKey: function () { return this.currentAppId + '_quiz'; },
                 makeUpgradeQuestion: function () {
                     var quiz = resolveFactoryQuiz(this.currentApp);
-                    var list = null;
-                    try { list = getDataList(quiz.listName); } catch (e) {}
-                    return buildUpgradeQuestion(list, quiz.questionIndex, quiz.resultIndex);
+                    var generated = null;
+                    try {
+                        // questionType 'text' renders the prompt as plain text for the
+                        // modal; generated.action still speaks text_to_speech prompts.
+                        generated = generateFromList(quiz.listName, quiz.questionIndex, quiz.resultIndex, this.quizKey(), quiz.setItems, 'text');
+                    } catch (e) {}
+                    if (!generated || !Array.isArray(generated.options) || generated.options.length < 2) return null;
+                    return {
+                        prompt: generated.question,
+                        answer: generated.result,
+                        options: this.shuffle(generated.options.slice()),
+                        action: generated.action,
+                        index: generated.questionIndex
+                    };
                 },
                 openUpgradeApproval: function (definition) {
                     var self = this;
@@ -1409,13 +1390,13 @@
                         self.pendingUpgrade = definition;
                         self._resolveUpgradeFt = resolve;
                         self.$nextTick(function () { if (self.$refs.confirmBtn) self.$refs.confirmBtn.focus(); });
-                        if (definition.question && definition.question.speak) self.speakQuizPrompt();
+                        if (definition.question) self.speakQuizPrompt();
                     });
                 },
                 speakQuizPrompt: function () {
                     var q = this.pendingUpgrade && this.pendingUpgrade.question;
-                    if (q && q.speak && typeof text_to_speech === 'function') {
-                        try { text_to_speech(q.prompt); } catch (e) {}
+                    if (q && typeof q.action === 'function') {
+                        try { q.action(); } catch (e) {}
                     }
                 },
                 quizOptionClass: function (option) {
@@ -1431,6 +1412,11 @@
                     this.quizChoice = option;
                     this.quizCorrect = option === q.answer;
                     try { (this.quizCorrect ? successSound : failureSound).play(); } catch (e) {}
+                    // Report the answer to the learning engine under the quiz key,
+                    // mirroring MCQComponent (-1 mastered a step, +1 needs practice).
+                    if (typeof q.index === 'number') {
+                        updateWeightForKey(this.quizKey(), q.index, this.quizCorrect ? -1 : 1);
+                    }
                     var self = this, accepted = this.quizCorrect;
                     this._quizTimerFt = setTimeout(function () {
                         self.resolveUpgradeChoice(accepted);
@@ -1523,7 +1509,6 @@
     global.resolveFactoryTheme = resolveFactoryTheme;
     global.getFactoryUpgradeDefinition = getUpgradeDefinition;
     global.resolveFactoryQuiz = resolveFactoryQuiz;
-    global.buildFactoryUpgradeQuestion = buildUpgradeQuestion;
     global.FT_QUIZ_DELAYS = FT_QUIZ_DELAYS;
     global.FactoryUpgradeApprovalService = UpgradeApprovalService;
     global.createFactoryTycoonComponent = createFactoryTycoonComponent;

--- a/games/factory-tycoon.js
+++ b/games/factory-tycoon.js
@@ -145,8 +145,60 @@
         };
     }
 
-    // Central upgrade approval adapter. Replace requestUpgradeApproval() with the
-    // educational question engine later; every purchase funnels through here.
+    // ---- educational question engine ------------------------------------------
+    // Every upgrade must be earned by answering a vocabulary question. The quiz
+    // list is configurable per app entry (quizListName/quizQuestionIndex/
+    // quizResultIndex in apps.js) and defaults to the Chapter 4 word list.
+    var FT_QUIZ_DEFAULTS = {listName: 'ENGLISH_CHAPTER4_ALL', questionIndex: 'english_name', resultIndex: 'hebrew'};
+    var FT_QUIZ_DELAYS = {correct: 700, wrong: 1700};
+
+    function resolveFactoryQuiz(app) {
+        app = app || {};
+        return {
+            listName: app.quizListName || FT_QUIZ_DEFAULTS.listName,
+            questionIndex: app.quizQuestionIndex || FT_QUIZ_DEFAULTS.questionIndex,
+            resultIndex: app.quizResultIndex || FT_QUIZ_DEFAULTS.resultIndex
+        };
+    }
+
+    function buildUpgradeQuestion(list, questionIndex, resultIndex, rng) {
+        rng = rng || Math.random;
+        if (!Array.isArray(list) || !list.length) return null;
+        var qi = Math.floor(rng() * list.length);
+        var item = list[qi];
+        if (!item || !item[questionIndex] || !item[resultIndex]) return null;
+        var answer = item[resultIndex].value;
+        if (typeof answer !== 'string' || !answer) return null;
+        var seen = {};
+        seen[answer] = true;
+        var pool = [];
+        list.forEach(function (other, index) {
+            if (index === qi || !other || !other[resultIndex]) return;
+            var value = other[resultIndex].value;
+            if (typeof value !== 'string' || !value || seen[value]) return;
+            seen[value] = true;
+            pool.push(value);
+        });
+        function shuffle(arr) {
+            for (var i = arr.length - 1; i > 0; i--) {
+                var j = Math.floor(rng() * (i + 1));
+                var t = arr[i]; arr[i] = arr[j]; arr[j] = t;
+            }
+            return arr;
+        }
+        if (!pool.length) return null;
+        var options = shuffle([answer].concat(shuffle(pool).slice(0, 3)));
+        var promptField = item[questionIndex];
+        return {
+            prompt: promptField.value,
+            speak: promptField.type === 'text_to_speech' || promptField.type === 'speech',
+            answer: answer,
+            options: options
+        };
+    }
+
+    // Central upgrade approval adapter. Every purchase funnels through here; the
+    // component attaches a quiz question and only resolves true on a correct answer.
     var UpgradeApprovalService = {
         requestUpgradeApproval: function (component, definition) {
             return component.openUpgradeApproval(definition);
@@ -172,7 +224,8 @@
         var palletStack = [];
         var signLights = [], signLit = false;
         var minZoom = 0.2, maxZoom = 1.5;
-        var spawnClock = 0;
+        var spawnClock = 0, badgeClock = 260;
+        var badges = {};         // machine id -> floating "+" upgrade badge
         var pinch = null, dragInfo = null, userTouched = false;
         var dust = [];
         var reduced = bridge.reducedMotion;
@@ -976,6 +1029,64 @@
             puffAt(b.centerX, b.centerY, 3, 0xffe9a8, b.width / 4);
         }
 
+        // -- upgrade "+" badges -------------------------------------------------
+        // A floating plus above every station that has a next upgrade: green and
+        // pulsing when affordable, gray with the price when money is still short.
+        function makeBadge(id) {
+            var m = machines[id];
+            if (!m || !m.root) return null;
+            var b = m.root.getBounds ? m.root.getBounds() : new P.Geom.Rectangle(m.root.x, m.root.y, m.w, m.h);
+            var by = b.top - 40;
+            if (by < 48) by = b.bottom + 44;    // the sign hugs the ceiling
+            var c = scene.add.container(b.centerX, by).setDepth(72).setVisible(false);
+            var ring = scene.add.circle(0, 0, 26, 0x57d06b).setStrokeStyle(5, 0x2b3145);
+            var barV = scene.add.rectangle(0, 0, 6.5, 24, 0xffffff);
+            var barH = scene.add.rectangle(0, 0, 24, 6.5, 0xffffff);
+            var cost = scene.add.text(0, 42, '', {
+                fontFamily: 'Arial, sans-serif', fontSize: '19px', fontStyle: '900',
+                color: '#ffffff', stroke: '#2b3145', strokeThickness: 5
+            }).setOrigin(0.5);
+            c.add([ring, barV, barH, cost]);
+            c.setSize(60, 60).setInteractive(new P.Geom.Rectangle(-30, -30, 60, 60), P.Geom.Rectangle.Contains);
+            c.input.cursor = 'pointer';
+            c.on('pointerup', function (pointer) { if (isTap(pointer)) bridge.onBadgeTap(id); });
+            badges[id] = {c: c, ring: ring, cost: cost, affordable: null, shown: false, tween: null};
+            return badges[id];
+        }
+
+        function refreshBadges() {
+            var hints = bridge.getUpgradeHints();
+            Object.keys(hints).forEach(function (id) {
+                var badge = badges[id] || makeBadge(id);
+                if (!badge) return;
+                var hint = hints[id];
+                if (!hint || !hint.available) {
+                    if (badge.shown) {
+                        badge.shown = false;
+                        badge.affordable = null;
+                        if (badge.tween) { badge.tween.stop(); badge.tween = null; }
+                        badge.c.setScale(1).setVisible(false);
+                    }
+                    return;
+                }
+                badge.c.setVisible(true);
+                badge.shown = true;
+                badge.cost.setText(String(hint.cost));
+                if (hint.affordable !== badge.affordable) {
+                    badge.affordable = hint.affordable;
+                    if (badge.tween) { badge.tween.stop(); badge.tween = null; badge.c.setScale(1); }
+                    if (hint.affordable) {
+                        badge.ring.setFillStyle(0x57d06b, 1);
+                        badge.c.setAlpha(1);
+                        if (!reduced) badge.tween = scene.tweens.add({targets: badge.c, scale: 1.16, duration: 470, yoyo: true, repeat: -1, ease: 'Sine.easeInOut'});
+                    } else {
+                        badge.ring.setFillStyle(0x8d99b5, 1);
+                        badge.c.setAlpha(0.88);
+                    }
+                }
+            });
+        }
+
         // -- lifecycle ----------------------------------------------------------------
         scene.create = function () {
             makeSoftTextures();
@@ -997,6 +1108,7 @@
             initialFrame();
             setupInput();
             applyDerived();
+            refreshBadges();
             spawnClock = bridge.cycleDuration() * 0.4; // first log appears quickly
 
             bridge.attach({
@@ -1004,6 +1116,7 @@
                 zoomIn: function () { zoomBy(1.22); },
                 zoomOut: function () { zoomBy(0.82); },
                 applyDerived: applyDerived,
+                refreshBadges: refreshBadges,
                 levelUpFx: levelUpFx,
                 clearSelection: function () { clearSelection(true); },
                 selectMachine: selectMachine
@@ -1040,6 +1153,12 @@
             if (spawnClock >= bridge.cycleDuration() && products.length < 7) {
                 spawnClock = 0;
                 spawnProduct();
+            }
+            // upgrade badges track money/purchases (cheap poll, ~3x per second)
+            badgeClock += dtMs;
+            if (badgeClock >= 320) {
+                badgeClock = 0;
+                refreshBadges();
             }
             // workers
             for (var i = 0; i < workers.length; i++) updateWorker(workers[i], dtMs);
@@ -1100,7 +1219,7 @@
                 </button>
               </section>
               <div class="ft-sr-live" aria-live="polite">{{ liveAnnouncement }}</div>
-              <div v-if="pendingUpgrade" class="ft-modal-scrim" @click.self="resolveUpgradeChoice(false)">
+              <div v-if="pendingUpgrade" class="ft-modal-scrim" @click.self="dismissUpgrade">
                 <section class="ft-modal" role="dialog" aria-modal="true" :aria-label="pendingUpgrade.title">
                   <h2>{{ pendingUpgrade.title }}</h2>
                   <p>{{ pendingUpgrade.description }}</p>
@@ -1109,10 +1228,29 @@
                     <div><dt>רמה חדשה</dt><dd>{{ pendingUpgrade.nextLevel }}</dd></div>
                     <div><dt>מחיר</dt><dd>{{ pendingUpgrade.cost }}</dd></div>
                   </dl>
-                  <div class="ft-modal-actions">
-                    <button type="button" @click="resolveUpgradeChoice(false)">ביטול</button>
-                    <button ref="confirmBtn" type="button" class="confirm" @click="resolveUpgradeChoice(true)">שדרוג</button>
-                  </div>
+                  <template v-if="pendingUpgrade.question">
+                    <p class="ft-quiz-callout">ענו נכון על השאלה כדי לאשר את השדרוג:</p>
+                    <button type="button" class="ft-quiz-prompt" @click="speakQuizPrompt">{{ pendingUpgrade.question.prompt }}</button>
+                    <div class="ft-quiz-options">
+                      <button v-for="option in pendingUpgrade.question.options" :key="option" type="button"
+                        :class="quizOptionClass(option)" :disabled="quizChoice !== null"
+                        @click="answerUpgradeQuestion(option)">{{ option }}</button>
+                    </div>
+                    <p class="ft-quiz-feedback" :class="{ok: quizCorrect, bad: quizChoice !== null && !quizCorrect}">
+                      <template v-if="quizChoice === null">&nbsp;</template>
+                      <template v-else-if="quizCorrect">תשובה נכונה! השדרוג יוצא לדרך</template>
+                      <template v-else>התשובה הנכונה: {{ pendingUpgrade.question.answer }}</template>
+                    </p>
+                    <div class="ft-modal-actions">
+                      <button type="button" :disabled="quizChoice !== null" @click="resolveUpgradeChoice(false)">ביטול</button>
+                    </div>
+                  </template>
+                  <template v-else>
+                    <div class="ft-modal-actions">
+                      <button type="button" @click="resolveUpgradeChoice(false)">ביטול</button>
+                      <button ref="confirmBtn" type="button" class="confirm" @click="resolveUpgradeChoice(true)">שדרוג</button>
+                    </div>
+                  </template>
                 </section>
               </div>
             </div>`,
@@ -1124,6 +1262,8 @@
                     money: 40,
                     moneyPop: false,
                     pendingUpgrade: null,
+                    quizChoice: null,
+                    quizCorrect: false,
                     selectedMachine: null,
                     liveAnnouncement: '',
                     reducedMotion: false,
@@ -1196,6 +1336,22 @@
                     }
                     return null;
                 },
+                upgradeHints: function () {
+                    var hints = {};
+                    Object.keys(STATION_INFO).forEach(function (id) {
+                        var next = this.nextUpgradeFor(id);
+                        hints[id] = next
+                            ? {available: true, affordable: this.money >= next.cost, cost: next.cost}
+                            : {available: false};
+                    }, this);
+                    return hints;
+                },
+                handleBadgeTap: function (id) {
+                    var next = this.nextUpgradeFor(id);
+                    if (!next) return;
+                    if (this._sceneApi) this._sceneApi.selectMachine(id);
+                    if (this.money >= next.cost) this.attemptUpgrade(next.index);
+                },
                 // ---- Phaser bootstrap ----
                 bootScene: function () {
                     if (typeof Phaser === 'undefined' || !this.$refs.stage) return;
@@ -1203,9 +1359,11 @@
                     var bridge = {
                         reducedMotion: this.reducedMotion,
                         getDerived: function () { return self.derived; },
+                        getUpgradeHints: function () { return self.upgradeHints(); },
                         cycleDuration: function () { return self.cycleDuration(); },
                         productValue: function () { return self.productValue(); },
                         onSelect: function (id) { self.selectedMachine = id && STATION_INFO[id] ? id : null; },
+                        onBadgeTap: function (id) { self.handleBadgeTap(id); },
                         onDeliver: function (value) { self.completeDelivery(value); },
                         attach: function (api) { self._sceneApi = api; }
                     };
@@ -1236,20 +1394,63 @@
                     this.selectedMachine = null;
                     if (this._sceneApi) this._sceneApi.clearSelection();
                 },
+                makeUpgradeQuestion: function () {
+                    var quiz = resolveFactoryQuiz(this.currentApp);
+                    var list = null;
+                    try { list = getDataList(quiz.listName); } catch (e) {}
+                    return buildUpgradeQuestion(list, quiz.questionIndex, quiz.resultIndex);
+                },
                 openUpgradeApproval: function (definition) {
                     var self = this;
+                    definition.question = this.makeUpgradeQuestion();
+                    this.quizChoice = null;
+                    this.quizCorrect = false;
                     return new Promise(function (resolve) {
                         self.pendingUpgrade = definition;
                         self._resolveUpgradeFt = resolve;
                         self.$nextTick(function () { if (self.$refs.confirmBtn) self.$refs.confirmBtn.focus(); });
+                        if (definition.question && definition.question.speak) self.speakQuizPrompt();
                     });
                 },
+                speakQuizPrompt: function () {
+                    var q = this.pendingUpgrade && this.pendingUpgrade.question;
+                    if (q && q.speak && typeof text_to_speech === 'function') {
+                        try { text_to_speech(q.prompt); } catch (e) {}
+                    }
+                },
+                quizOptionClass: function (option) {
+                    var q = this.pendingUpgrade && this.pendingUpgrade.question;
+                    if (!q || this.quizChoice === null) return '';
+                    if (option === q.answer) return 'correct';
+                    if (option === this.quizChoice) return 'wrong';
+                    return '';
+                },
+                answerUpgradeQuestion: function (option) {
+                    var q = this.pendingUpgrade && this.pendingUpgrade.question;
+                    if (!q || this.quizChoice !== null) return;
+                    this.quizChoice = option;
+                    this.quizCorrect = option === q.answer;
+                    try { (this.quizCorrect ? successSound : failureSound).play(); } catch (e) {}
+                    var self = this, accepted = this.quizCorrect;
+                    this._quizTimerFt = setTimeout(function () {
+                        self.resolveUpgradeChoice(accepted);
+                    }, accepted ? FT_QUIZ_DELAYS.correct : FT_QUIZ_DELAYS.wrong);
+                },
                 confirmUpgrade: function (item) { return UpgradeApprovalService.requestUpgradeApproval(this, getUpgradeDefinition(item)); },
+                dismissUpgrade: function () {
+                    // scrim taps must not skip a revealed answer, only an unanswered question
+                    if (this.quizChoice !== null) return;
+                    this.resolveUpgradeChoice(false);
+                },
                 resolveUpgradeChoice: function (accepted) {
                     if (!this.pendingUpgrade) return;
+                    clearTimeout(this._quizTimerFt);
+                    this._quizTimerFt = null;
                     var resolve = this._resolveUpgradeFt;
                     this.pendingUpgrade = null;
                     this._resolveUpgradeFt = null;
+                    this.quizChoice = null;
+                    this.quizCorrect = false;
                     if (resolve) resolve(accepted);
                 },
                 attemptUpgrade: async function (index) {
@@ -1303,6 +1504,7 @@
             beforeDestroy: function () {
                 this._destroyedFt = true;
                 clearTimeout(this._moneyTimerFt);
+                clearTimeout(this._quizTimerFt);
                 this.saveMoney();
                 if (this.pendingUpgrade) this.resolveUpgradeChoice(false);
                 if (this._game) {
@@ -1320,6 +1522,9 @@
     global.deriveFactoryState = deriveFactoryState;
     global.resolveFactoryTheme = resolveFactoryTheme;
     global.getFactoryUpgradeDefinition = getUpgradeDefinition;
+    global.resolveFactoryQuiz = resolveFactoryQuiz;
+    global.buildFactoryUpgradeQuestion = buildUpgradeQuestion;
+    global.FT_QUIZ_DELAYS = FT_QUIZ_DELAYS;
     global.FactoryUpgradeApprovalService = UpgradeApprovalService;
     global.createFactoryTycoonComponent = createFactoryTycoonComponent;
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'my-app-cache-v40';
+const CACHE_NAME = 'my-app-cache-v41';
 const CORE_ASSETS = [
   '/',
   '/index.html',

--- a/tests/factory_tycoon_test.js
+++ b/tests/factory_tycoon_test.js
@@ -194,7 +194,106 @@ ctx.successSound = {play() {}};
     await methods.attemptUpgrade.call(stageContinues, 0);
     check('reloadProgress() === true saves score and continues', saveScoreCalls === 1);
 
-    console.log('--- 5. legacy registration ---');
+    console.log('--- 5. quiz question builder (Chapter 4) ---');
+    const quizDefaults = ctx.resolveFactoryQuiz({});
+    check('quiz defaults to the Chapter 4 word list',
+        quizDefaults.listName === 'ENGLISH_CHAPTER4_ALL' && quizDefaults.questionIndex === 'english_name' && quizDefaults.resultIndex === 'hebrew',
+        JSON.stringify(quizDefaults));
+    const quizCustom = ctx.resolveFactoryQuiz({quizListName: 'L', quizQuestionIndex: 'q', quizResultIndex: 'r'});
+    check('quiz config is overridable per app entry',
+        quizCustom.listName === 'L' && quizCustom.questionIndex === 'q' && quizCustom.resultIndex === 'r');
+
+    const vocab = [
+        {hebrew: {type: 'text', value: 'אומנות'}, english_name: {type: 'text_to_speech', value: 'Art'}},
+        {hebrew: {type: 'text', value: 'מוזיקה'}, english_name: {type: 'text_to_speech', value: 'Music'}},
+        {hebrew: {type: 'text', value: 'להקה'}, english_name: {type: 'text_to_speech', value: 'Band'}},
+        {hebrew: {type: 'text', value: 'גיטרה'}, english_name: {type: 'text_to_speech', value: 'Guitar'}},
+        {hebrew: {type: 'text', value: 'זמר'}, english_name: {type: 'text_to_speech', value: 'Singer'}},
+    ];
+    const question = ctx.buildFactoryUpgradeQuestion(vocab, 'english_name', 'hebrew', () => 0);
+    check('question prompt comes from the configured question field', question && question.prompt === 'Art', JSON.stringify(question));
+    check('a text_to_speech question field is marked spoken', question && question.speak === true);
+    check('the answer is the matching translation', question && question.answer === 'אומנות');
+    check('question has 4 unique options including the answer',
+        question && question.options.length === 4 && new Set(question.options).size === 4 && question.options.includes(question.answer),
+        question && JSON.stringify(question.options));
+    check('an empty list yields no question (plain confirm fallback)',
+        ctx.buildFactoryUpgradeQuestion([], 'english_name', 'hebrew') === null);
+    check('a single-item list yields no question (no distractors possible)',
+        ctx.buildFactoryUpgradeQuestion(vocab.slice(0, 1), 'english_name', 'hebrew', () => 0) === null);
+
+    console.log('--- 6. quiz gate: correct answer approves, wrong answer cancels ---');
+    ctx.FT_QUIZ_DELAYS.correct = 0;
+    ctx.FT_QUIZ_DELAYS.wrong = 0;
+    ctx.failureSound = {play() {}};
+    ctx.getDataList = name => {
+        if (name === 'ENGLISH_CHAPTER4_ALL') return vocab;
+        throw new Error('List does not exist');
+    };
+    function makeQuizInstance(overrides) {
+        return makeUpgradeInstance(definition, Object.assign({
+            $refs: {},
+            confirmUpgrade: methods.confirmUpgrade,
+            nextUpgradeFor: methods.nextUpgradeFor,
+            openUpgradeApproval: methods.openUpgradeApproval,
+            makeUpgradeQuestion: methods.makeUpgradeQuestion,
+            speakQuizPrompt: methods.speakQuizPrompt,
+            answerUpgradeQuestion: methods.answerUpgradeQuestion,
+            resolveUpgradeChoice: methods.resolveUpgradeChoice,
+            dismissUpgrade: methods.dismissUpgrade,
+            quizOptionClass: methods.quizOptionClass,
+        }, overrides));
+    }
+
+    reports.length = 0;
+    const quizRight = makeQuizInstance({});
+    const rightAttempt = methods.attemptUpgrade.call(quizRight, 0);
+    check('opening the upgrade dialog attaches a quiz question',
+        !!(quizRight.pendingUpgrade && quizRight.pendingUpgrade.question), JSON.stringify(quizRight.pendingUpgrade));
+    methods.answerUpgradeQuestion.call(quizRight, quizRight.pendingUpgrade.question.answer);
+    check('a correct choice is recorded as correct', quizRight.quizCorrect === true);
+    await rightAttempt;
+    check('a correct answer purchases the upgrade and reports one weight update',
+        quizRight.purchasedMap[0] === true && quizRight.money === 50 && reports.length === 1, JSON.stringify(reports));
+
+    reports.length = 0;
+    const quizWrong = makeQuizInstance({});
+    const wrongAttempt = methods.attemptUpgrade.call(quizWrong, 0);
+    const wrongOption = quizWrong.pendingUpgrade.question.options.find(option => option !== quizWrong.pendingUpgrade.question.answer);
+    methods.answerUpgradeQuestion.call(quizWrong, wrongOption);
+    methods.answerUpgradeQuestion.call(quizWrong, quizWrong.pendingUpgrade.question.answer);
+    check('the first answer locks in; a second click is ignored',
+        quizWrong.quizChoice === wrongOption && quizWrong.quizCorrect === false);
+    methods.dismissUpgrade.call(quizWrong);
+    check('a scrim tap after answering does not close the reveal early', quizWrong.pendingUpgrade !== null);
+    await wrongAttempt;
+    check('a wrong answer cancels the purchase: money kept, nothing bought, no weight update',
+        quizWrong.money === 100 && !quizWrong.purchasedMap[0] && reports.length === 0);
+
+    reports.length = 0;
+    const quizCancel = makeQuizInstance({});
+    const cancelAttempt = methods.attemptUpgrade.call(quizCancel, 0);
+    methods.dismissUpgrade.call(quizCancel);
+    await cancelAttempt;
+    check('a scrim tap before answering cancels cleanly', quizCancel.money === 100 && reports.length === 0 && quizCancel.pendingUpgrade === null);
+
+    console.log('--- 7. upgrade hints drive the scene "+" badges ---');
+    const hintsRich = makeQuizInstance({money: 100});
+    const richHints = methods.upgradeHints.call(hintsRich);
+    check('a station with a pending upgrade is marked available and affordable',
+        richHints.sawmill && richHints.sawmill.available === true && richHints.sawmill.affordable === true && richHints.sawmill.cost === 50,
+        JSON.stringify(richHints.sawmill));
+    check('a station with no pending upgrade is marked unavailable',
+        richHints.packaging && richHints.packaging.available === false, JSON.stringify(richHints.packaging));
+    const hintsPoor = makeQuizInstance({money: 10});
+    const poorHints = methods.upgradeHints.call(hintsPoor);
+    check('an unaffordable upgrade stays visible but not affordable',
+        poorHints.sawmill.available === true && poorHints.sawmill.affordable === false);
+    const hintsDone = makeQuizInstance({purchasedMap: {0: true}});
+    const doneHints = methods.upgradeHints.call(hintsDone);
+    check('a purchased upgrade no longer advertises a badge', doneHints.sawmill.available === false);
+
+    console.log('--- 8. legacy registration ---');
     function makeStorage() {
         const map = new Map();
         return {
@@ -231,8 +330,18 @@ ctx.successSound = {play() {}};
     );
     check('legacy menu registers a complete factory_tycoon app',
         legacyFactory && legacyFactory.listName === 'FACTORY_UPGRADES' && legacyFactory.setItems === 4, JSON.stringify(legacyFactory));
+    check('the app entry wires the Chapter 4 quiz (list + fields)',
+        legacyFactory && legacyFactory.quizListName === 'ENGLISH_CHAPTER4_ALL' &&
+        legacyFactory.quizQuestionIndex === 'english_name' && legacyFactory.quizResultIndex === 'hebrew',
+        JSON.stringify(legacyFactory));
     check('the registered list resolves through the shared data API and passes validation',
         ctx.validateFactoryUpgrades(integration.DATA.FACTORY_UPGRADES).length === 0);
+    const chapter4List = integration.DATA.ENGLISH_CHAPTER4_ALL;
+    const chapter4Question = ctx.buildFactoryUpgradeQuestion(chapter4List, 'english_name', 'hebrew');
+    check('the real Chapter 4 list builds a full 4-option question',
+        Array.isArray(chapter4List) && chapter4List.length > 0 &&
+        chapter4Question && chapter4Question.options.length === 4 && chapter4Question.options.includes(chapter4Question.answer),
+        JSON.stringify(chapter4Question));
 
     console.log(`\n${passed} passed, ${failed} failed`);
     if (failed) process.exit(1);

--- a/tests/factory_tycoon_test.js
+++ b/tests/factory_tycoon_test.js
@@ -194,47 +194,39 @@ ctx.successSound = {play() {}};
     await methods.attemptUpgrade.call(stageContinues, 0);
     check('reloadProgress() === true saves score and continues', saveScoreCalls === 1);
 
-    console.log('--- 5. quiz question builder (Chapter 4) ---');
+    console.log('--- 5. quiz config + engine-served questions ---');
     const quizDefaults = ctx.resolveFactoryQuiz({});
-    check('quiz defaults to the Chapter 4 word list',
-        quizDefaults.listName === 'ENGLISH_CHAPTER4_ALL' && quizDefaults.questionIndex === 'english_name' && quizDefaults.resultIndex === 'hebrew',
+    check('quiz defaults to the Chapter 4 word list in batches of 10',
+        quizDefaults.listName === 'ENGLISH_CHAPTER4_ALL' && quizDefaults.questionIndex === 'english_name' &&
+        quizDefaults.resultIndex === 'hebrew' && quizDefaults.setItems === 10,
         JSON.stringify(quizDefaults));
-    const quizCustom = ctx.resolveFactoryQuiz({quizListName: 'L', quizQuestionIndex: 'q', quizResultIndex: 'r'});
+    const quizCustom = ctx.resolveFactoryQuiz({quizListName: 'L', quizQuestionIndex: 'q', quizResultIndex: 'r', quizSetItems: 3});
     check('quiz config is overridable per app entry',
-        quizCustom.listName === 'L' && quizCustom.questionIndex === 'q' && quizCustom.resultIndex === 'r');
+        quizCustom.listName === 'L' && quizCustom.questionIndex === 'q' && quizCustom.resultIndex === 'r' && quizCustom.setItems === 3);
 
-    const vocab = [
-        {hebrew: {type: 'text', value: 'אומנות'}, english_name: {type: 'text_to_speech', value: 'Art'}},
-        {hebrew: {type: 'text', value: 'מוזיקה'}, english_name: {type: 'text_to_speech', value: 'Music'}},
-        {hebrew: {type: 'text', value: 'להקה'}, english_name: {type: 'text_to_speech', value: 'Band'}},
-        {hebrew: {type: 'text', value: 'גיטרה'}, english_name: {type: 'text_to_speech', value: 'Guitar'}},
-        {hebrew: {type: 'text', value: 'זמר'}, english_name: {type: 'text_to_speech', value: 'Singer'}},
-    ];
-    const question = ctx.buildFactoryUpgradeQuestion(vocab, 'english_name', 'hebrew', () => 0);
-    check('question prompt comes from the configured question field', question && question.prompt === 'Art', JSON.stringify(question));
-    check('a text_to_speech question field is marked spoken', question && question.speak === true);
-    check('the answer is the matching translation', question && question.answer === 'אומנות');
-    check('question has 4 unique options including the answer',
-        question && question.options.length === 4 && new Set(question.options).size === 4 && question.options.includes(question.answer),
-        question && JSON.stringify(question.options));
-    check('an empty list yields no question (plain confirm fallback)',
-        ctx.buildFactoryUpgradeQuestion([], 'english_name', 'hebrew') === null);
-    check('a single-item list yields no question (no distractors possible)',
-        ctx.buildFactoryUpgradeQuestion(vocab.slice(0, 1), 'english_name', 'hebrew', () => 0) === null);
-
-    console.log('--- 6. quiz gate: correct answer approves, wrong answer cancels ---');
+    console.log('--- 6. quiz gate: the shared engine selects and records answers ---');
     ctx.FT_QUIZ_DELAYS.correct = 0;
     ctx.FT_QUIZ_DELAYS.wrong = 0;
     ctx.failureSound = {play() {}};
-    ctx.getDataList = name => {
-        if (name === 'ENGLISH_CHAPTER4_ALL') return vocab;
-        throw new Error('List does not exist');
+    let engineCalls = [];
+    let quizSpoken = 0;
+    ctx.generateFromList = (listName, questionIndex, resultIndex, key, setItems, questionType) => {
+        engineCalls.push({listName, questionIndex, resultIndex, key, setItems, questionType});
+        return {
+            question: 'Art',
+            result: 'אומנות',
+            options: ['אומנות', 'מוזיקה', 'להקה', 'גיטרה'],
+            action: () => { quizSpoken += 1; },
+            questionIndex: 7,
+        };
     };
     function makeQuizInstance(overrides) {
         return makeUpgradeInstance(definition, Object.assign({
             $refs: {},
+            shuffle: a => a,
             confirmUpgrade: methods.confirmUpgrade,
             nextUpgradeFor: methods.nextUpgradeFor,
+            quizKey: methods.quizKey,
             openUpgradeApproval: methods.openUpgradeApproval,
             makeUpgradeQuestion: methods.makeUpgradeQuestion,
             speakQuizPrompt: methods.speakQuizPrompt,
@@ -246,15 +238,28 @@ ctx.successSound = {play() {}};
     }
 
     reports.length = 0;
+    engineCalls = [];
     const quizRight = makeQuizInstance({});
     const rightAttempt = methods.attemptUpgrade.call(quizRight, 0);
-    check('opening the upgrade dialog attaches a quiz question',
-        !!(quizRight.pendingUpgrade && quizRight.pendingUpgrade.question), JSON.stringify(quizRight.pendingUpgrade));
+    check('opening the upgrade dialog asks the shared engine for a question',
+        engineCalls.length === 1 && engineCalls[0].listName === 'ENGLISH_CHAPTER4_ALL' && engineCalls[0].questionIndex === 'english_name' &&
+        engineCalls[0].resultIndex === 'hebrew' && engineCalls[0].setItems === 10 && engineCalls[0].questionType === 'text',
+        JSON.stringify(engineCalls));
+    check('the quiz uses its own knowledge key, separate from the tech tree',
+        engineCalls[0].key === 'ft-test_quiz');
+    check('the engine question is attached to the dialog',
+        !!(quizRight.pendingUpgrade && quizRight.pendingUpgrade.question) && quizRight.pendingUpgrade.question.prompt === 'Art' &&
+        quizRight.pendingUpgrade.question.options.length === 4, JSON.stringify(quizRight.pendingUpgrade));
+    check('opening the dialog speaks the prompt via the engine action', quizSpoken === 1);
     methods.answerUpgradeQuestion.call(quizRight, quizRight.pendingUpgrade.question.answer);
     check('a correct choice is recorded as correct', quizRight.quizCorrect === true);
     await rightAttempt;
-    check('a correct answer purchases the upgrade and reports one weight update',
-        quizRight.purchasedMap[0] === true && quizRight.money === 50 && reports.length === 1, JSON.stringify(reports));
+    check('a correct answer reports -1 on the quiz key, like MCQComponent',
+        reports.some(r => r.key === 'ft-test_quiz' && r.index === 7 && r.change === -1), JSON.stringify(reports));
+    check('a correct answer still purchases the upgrade and reports the tech-tree item',
+        quizRight.purchasedMap[0] === true && quizRight.money === 50 &&
+        reports.some(r => r.key === 'ft-test' && r.index === 0 && r.change === -15) && reports.length === 2,
+        JSON.stringify(reports));
 
     reports.length = 0;
     const quizWrong = makeQuizInstance({});
@@ -267,15 +272,33 @@ ctx.successSound = {play() {}};
     methods.dismissUpgrade.call(quizWrong);
     check('a scrim tap after answering does not close the reveal early', quizWrong.pendingUpgrade !== null);
     await wrongAttempt;
-    check('a wrong answer cancels the purchase: money kept, nothing bought, no weight update',
-        quizWrong.money === 100 && !quizWrong.purchasedMap[0] && reports.length === 0);
+    check('a wrong answer reports +1 on the quiz key and cancels the purchase',
+        quizWrong.money === 100 && !quizWrong.purchasedMap[0] &&
+        reports.length === 1 && reports[0].key === 'ft-test_quiz' && reports[0].change === 1,
+        JSON.stringify(reports));
 
     reports.length = 0;
     const quizCancel = makeQuizInstance({});
     const cancelAttempt = methods.attemptUpgrade.call(quizCancel, 0);
     methods.dismissUpgrade.call(quizCancel);
     await cancelAttempt;
-    check('a scrim tap before answering cancels cleanly', quizCancel.money === 100 && reports.length === 0 && quizCancel.pendingUpgrade === null);
+    check('a scrim tap before answering cancels cleanly with no reports',
+        quizCancel.money === 100 && reports.length === 0 && quizCancel.pendingUpgrade === null);
+
+    reports.length = 0;
+    ctx.generateFromList = () => { throw new Error('List does not exist'); };
+    const quizFallback = makeQuizInstance({confirmUpgrade: methods.confirmUpgrade});
+    const fallbackAttempt = methods.attemptUpgrade.call(quizFallback, 0);
+    check('an unavailable quiz list falls back to the plain confirm dialog',
+        quizFallback.pendingUpgrade !== null && quizFallback.pendingUpgrade.question === null);
+    methods.resolveUpgradeChoice.call(quizFallback, true);
+    await fallbackAttempt;
+    check('the fallback confirm still purchases through the same gate',
+        quizFallback.purchasedMap[0] === true && reports.length === 1 && reports[0].key === 'ft-test');
+    ctx.generateFromList = (listName, questionIndex, resultIndex, key, setItems, questionType) => {
+        engineCalls.push({listName, questionIndex, resultIndex, key, setItems, questionType});
+        return {question: 'Art', result: 'אומנות', options: ['אומנות', 'מוזיקה', 'להקה', 'גיטרה'], action: () => { quizSpoken += 1; }, questionIndex: 7};
+    };
 
     console.log('--- 7. upgrade hints drive the scene "+" badges ---');
     const hintsRich = makeQuizInstance({money: 100});
@@ -330,18 +353,36 @@ ctx.successSound = {play() {}};
     );
     check('legacy menu registers a complete factory_tycoon app',
         legacyFactory && legacyFactory.listName === 'FACTORY_UPGRADES' && legacyFactory.setItems === 4, JSON.stringify(legacyFactory));
-    check('the app entry wires the Chapter 4 quiz (list + fields)',
+    check('the app entry wires the Chapter 4 quiz (list + fields + batch size)',
         legacyFactory && legacyFactory.quizListName === 'ENGLISH_CHAPTER4_ALL' &&
-        legacyFactory.quizQuestionIndex === 'english_name' && legacyFactory.quizResultIndex === 'hebrew',
+        legacyFactory.quizQuestionIndex === 'english_name' && legacyFactory.quizResultIndex === 'hebrew' &&
+        legacyFactory.quizSetItems === 10,
         JSON.stringify(legacyFactory));
     check('the registered list resolves through the shared data API and passes validation',
         ctx.validateFactoryUpgrades(integration.DATA.FACTORY_UPGRADES).length === 0);
-    const chapter4List = integration.DATA.ENGLISH_CHAPTER4_ALL;
-    const chapter4Question = ctx.buildFactoryUpgradeQuestion(chapter4List, 'english_name', 'hebrew');
-    check('the real Chapter 4 list builds a full 4-option question',
-        Array.isArray(chapter4List) && chapter4List.length > 0 &&
-        chapter4Question && chapter4Question.options.length === 4 && chapter4Question.options.includes(chapter4Question.answer),
-        JSON.stringify(chapter4Question));
+
+    // The quiz rides the real learning engine: weighted selection under its own
+    // knowledge key, seeded and updated exactly like a regular MCQ app.
+    const quizGenerated = vm.runInContext(
+        `generateFromList('ENGLISH_CHAPTER4_ALL', 'english_name', 'hebrew', '5_0_quiz', 10, 'text')`,
+        integration
+    );
+    check('the real engine serves a Chapter 4 question under the quiz key',
+        quizGenerated && typeof quizGenerated.question === 'string' && quizGenerated.options.length === 4 &&
+        quizGenerated.options.includes(quizGenerated.result), JSON.stringify(quizGenerated));
+    check('questionType "text" renders the prompt as plain text for the modal',
+        quizGenerated && !/^</.test(quizGenerated.question));
+    const chapter4Length = integration.DATA.ENGLISH_CHAPTER4_ALL.length;
+    const quizWeights = vm.runInContext(`JSON.parse(localStorage.getItem(getWeightsKey('5_0_quiz')))`, integration);
+    check('quiz weights seed like a regular app: first batch of 10 unlocked, the rest locked',
+        Array.isArray(quizWeights) && quizWeights.length === chapter4Length &&
+        quizWeights.slice(0, 10).every(w => w === 5) && quizWeights.slice(10).every(w => w === -1),
+        JSON.stringify(quizWeights));
+    check('the engine picked the question from the unlocked batch', quizGenerated.questionIndex < 10);
+    vm.runInContext(`updateWeightForKey('5_0_quiz', ${quizGenerated.questionIndex}, -1)`, integration);
+    const afterAnswer = vm.runInContext(`JSON.parse(localStorage.getItem(getWeightsKey('5_0_quiz')))`, integration);
+    check('a reported correct answer lowers that word\'s weight from 5 to 4',
+        afterAnswer[quizGenerated.questionIndex] === 4);
 
     console.log(`\n${passed} passed, ${failed} failed`);
     if (failed) process.exit(1);


### PR DESCRIPTION
Players couldn't tell which stations could be upgraded. Every station
with a pending tech-tree item now shows a floating "+" badge in the
scene: green and pulsing when affordable, gray with the price when
money is short. Tapping a badge selects the station and, when
affordable, opens the upgrade flow directly.

Upgrades are now earned by answering a vocabulary question. The
confirmation dialog presents a Chapter 4 English word (spoken via TTS)
with four Hebrew options; a correct answer approves the purchase, a
wrong answer reveals the correct translation and cancels without
spending money. The quiz list and fields are configurable per app
entry (quizListName/quizQuestionIndex/quizResultIndex) and default to
ENGLISH_CHAPTER4_ALL, with a plain confirm fallback when no quiz list
resolves.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NRTNtXovWNTa6DTVByTkKf